### PR TITLE
Fix cargo build by adding libc dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,8 +6,15 @@ version = 4
 name = "kayton"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "libc"
+version = "0.2.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ windows-sys = { version = "0.60.2", features = [
     "Win32_Storage",
     "Win32_Storage_FileSystem"
 ] }
+libc = "0.2"


### PR DESCRIPTION
## Summary
- include `libc` crate for UNIX builds

## Testing
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688a82876ee0832c82dcd9fa919913af