### PR TITLE
Add unit tests for write module

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -44,3 +44,73 @@ pub fn println_to_console(message: &[u8]) {
     buffer.extend_from_slice(NL);
     print_to_console(&buffer);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    mod unix {
+        use super::*;
+        use std::io::Read;
+        use std::os::unix::io::{FromRawFd, RawFd};
+
+        /// Capture output written to STDOUT by temporarily redirecting it to a pipe.
+        fn capture_stdout<F: FnOnce()>(func: F) -> Vec<u8> {
+            unsafe {
+                let mut fds: [RawFd; 2] = [0; 2];
+                assert_eq!(libc::pipe(fds.as_mut_ptr()), 0, "pipe failed");
+
+                let stdout_fd = libc::STDOUT_FILENO;
+                let saved_fd = libc::dup(stdout_fd);
+                assert!(saved_fd >= 0, "dup failed");
+
+                assert_eq!(libc::dup2(fds[1], stdout_fd), stdout_fd, "dup2 failed");
+                libc::close(fds[1]);
+
+                func();
+
+                assert_eq!(libc::dup2(saved_fd, stdout_fd), stdout_fd, "restore failed");
+                libc::close(saved_fd);
+
+                let mut file = std::fs::File::from_raw_fd(fds[0]);
+                let mut buffer = Vec::new();
+                file.read_to_end(&mut buffer).unwrap();
+                buffer
+            }
+        }
+
+        #[test]
+        fn test_print_to_console() {
+            let msg = b"hello";
+            let out = capture_stdout(|| print_to_console(msg));
+            assert_eq!(out.as_slice(), msg);
+        }
+
+        #[test]
+        fn test_println_to_console() {
+            let msg = b"hello";
+            let mut expected = Vec::new();
+            expected.extend_from_slice(msg);
+            expected.extend_from_slice(NL);
+            let out = capture_stdout(|| println_to_console(msg));
+            assert_eq!(out, expected);
+        }
+    }
+
+    #[cfg(windows)]
+    mod windows {
+        use super::*;
+
+        #[test]
+        fn test_print_to_console() {
+            // On Windows, simply ensure the function does not panic.
+            print_to_console(b"hello");
+        }
+
+        #[test]
+        fn test_println_to_console() {
+            println_to_console(b"hello");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `print_to_console` and `println_to_console` work
- capture stdout on Unix to validate console output

## Testing
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_688a8450e06c832ca625337367842433