### PR TITLE
Add gte/lt/lte operations to VM

### DIFF
--- a/src/vm/bytecode_builder.rs
+++ b/src/vm/bytecode_builder.rs
@@ -93,6 +93,27 @@ impl BytecodeBuilder {
         self.bytecode.push(dst);
     }
 
+    pub fn gte_i64(&mut self, r1: u8, r2: u8, dst: u8) {
+        self.bytecode.push(GTE_I64);
+        self.bytecode.push(r1);
+        self.bytecode.push(r2);
+        self.bytecode.push(dst);
+    }
+
+    pub fn lt_i64(&mut self, r1: u8, r2: u8, dst: u8) {
+        self.bytecode.push(LT_I64);
+        self.bytecode.push(r1);
+        self.bytecode.push(r2);
+        self.bytecode.push(dst);
+    }
+
+    pub fn lte_i64(&mut self, r1: u8, r2: u8, dst: u8) {
+        self.bytecode.push(LTE_I64);
+        self.bytecode.push(r1);
+        self.bytecode.push(r2);
+        self.bytecode.push(dst);
+    }
+
     pub fn add_f64(&mut self, r1: u8, r2: u8, dst: u8) {
         self.bytecode.push(ADD_F64);
         self.bytecode.push(r1);
@@ -116,6 +137,27 @@ impl BytecodeBuilder {
 
     pub fn gt_f64(&mut self, r1: u8, r2: u8, dst: u8) {
         self.bytecode.push(GT_F64);
+        self.bytecode.push(r1);
+        self.bytecode.push(r2);
+        self.bytecode.push(dst);
+    }
+
+    pub fn gte_f64(&mut self, r1: u8, r2: u8, dst: u8) {
+        self.bytecode.push(GTE_F64);
+        self.bytecode.push(r1);
+        self.bytecode.push(r2);
+        self.bytecode.push(dst);
+    }
+
+    pub fn lt_f64(&mut self, r1: u8, r2: u8, dst: u8) {
+        self.bytecode.push(LT_F64);
+        self.bytecode.push(r1);
+        self.bytecode.push(r2);
+        self.bytecode.push(dst);
+    }
+
+    pub fn lte_f64(&mut self, r1: u8, r2: u8, dst: u8) {
+        self.bytecode.push(LTE_F64);
         self.bytecode.push(r1);
         self.bytecode.push(r2);
         self.bytecode.push(dst);

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -28,6 +28,12 @@ pub const F64_TO_I64: u8 = 0x0E;
 pub const JUMP_BACKWARD_IF_FALSE: u8 = 0x0F;
 pub const JUMP_BACKWARD_IF_TRUE: u8 = 0x10;
 pub const JUMP_FORWARD_IF_TRUE: u8 = 0x11;
+pub const GTE_I64: u8 = 0x12;
+pub const LT_I64: u8 = 0x13;
+pub const LTE_I64: u8 = 0x14;
+pub const GTE_F64: u8 = 0x15;
+pub const LT_F64: u8 = 0x16;
+pub const LTE_F64: u8 = 0x17;
 
 #[derive(Debug)]
 pub enum VmError {
@@ -211,6 +217,42 @@ impl VirtualMachine {
                 let val2 = self.get_i64(r2);
                 self.set_i64(dst, if val1 > val2 { 1 } else { 0 });
             }
+            GTE_I64 => {
+                if *pc + 2 >= bytecode.len() {
+                    return Err(VmError::UnexpectedEndOfProgram);
+                }
+                let r1 = bytecode[*pc];
+                let r2 = bytecode[*pc + 1];
+                let dst = bytecode[*pc + 2];
+                *pc += 3;
+                let val1 = self.get_i64(r1);
+                let val2 = self.get_i64(r2);
+                self.set_i64(dst, if val1 >= val2 { 1 } else { 0 });
+            }
+            LT_I64 => {
+                if *pc + 2 >= bytecode.len() {
+                    return Err(VmError::UnexpectedEndOfProgram);
+                }
+                let r1 = bytecode[*pc];
+                let r2 = bytecode[*pc + 1];
+                let dst = bytecode[*pc + 2];
+                *pc += 3;
+                let val1 = self.get_i64(r1);
+                let val2 = self.get_i64(r2);
+                self.set_i64(dst, if val1 < val2 { 1 } else { 0 });
+            }
+            LTE_I64 => {
+                if *pc + 2 >= bytecode.len() {
+                    return Err(VmError::UnexpectedEndOfProgram);
+                }
+                let r1 = bytecode[*pc];
+                let r2 = bytecode[*pc + 1];
+                let dst = bytecode[*pc + 2];
+                *pc += 3;
+                let val1 = self.get_i64(r1);
+                let val2 = self.get_i64(r2);
+                self.set_i64(dst, if val1 <= val2 { 1 } else { 0 });
+            }
             ADD_F64 => {
                 // Format: [opcode, r1, r2, dst]
                 if *pc + 2 >= bytecode.len() {
@@ -262,6 +304,42 @@ impl VirtualMachine {
                 let val1 = self.get_f64(r1);
                 let val2 = self.get_f64(r2);
                 self.set_i64(dst, if val1 > val2 { 1 } else { 0 });
+            }
+            GTE_F64 => {
+                if *pc + 2 >= bytecode.len() {
+                    return Err(VmError::UnexpectedEndOfProgram);
+                }
+                let r1 = bytecode[*pc];
+                let r2 = bytecode[*pc + 1];
+                let dst = bytecode[*pc + 2];
+                *pc += 3;
+                let val1 = self.get_f64(r1);
+                let val2 = self.get_f64(r2);
+                self.set_i64(dst, if val1 >= val2 { 1 } else { 0 });
+            }
+            LT_F64 => {
+                if *pc + 2 >= bytecode.len() {
+                    return Err(VmError::UnexpectedEndOfProgram);
+                }
+                let r1 = bytecode[*pc];
+                let r2 = bytecode[*pc + 1];
+                let dst = bytecode[*pc + 2];
+                *pc += 3;
+                let val1 = self.get_f64(r1);
+                let val2 = self.get_f64(r2);
+                self.set_i64(dst, if val1 < val2 { 1 } else { 0 });
+            }
+            LTE_F64 => {
+                if *pc + 2 >= bytecode.len() {
+                    return Err(VmError::UnexpectedEndOfProgram);
+                }
+                let r1 = bytecode[*pc];
+                let r2 = bytecode[*pc + 1];
+                let dst = bytecode[*pc + 2];
+                *pc += 3;
+                let val1 = self.get_f64(r1);
+                let val2 = self.get_f64(r2);
+                self.set_i64(dst, if val1 <= val2 { 1 } else { 0 });
             }
             JUMP_FORWARD_IF_FALSE => {
                 // Format: [opcode, cond_reg, target[2]]

--- a/src/vm/print_bytecode.rs
+++ b/src/vm/print_bytecode.rs
@@ -128,6 +128,45 @@ pub fn format_bytecode(bytecode: &[u8]) -> Result<String, String> {
                 pc += 3;
                 output.push_str(&format!("{} GT_I64 r{}, r{}, r{}\n", start_pc, r1, r2, dst));
             }
+            GTE_I64 => {
+                if pc + 2 >= bytecode.len() {
+                    return Err(format!(
+                        "Incomplete GTE_I64 instruction at pc {}: missing register operands",
+                        start_pc
+                    ));
+                }
+                let r1 = bytecode[pc];
+                let r2 = bytecode[pc + 1];
+                let dst = bytecode[pc + 2];
+                pc += 3;
+                output.push_str(&format!("{} GTE_I64 r{}, r{}, r{}\n", start_pc, r1, r2, dst));
+            }
+            LT_I64 => {
+                if pc + 2 >= bytecode.len() {
+                    return Err(format!(
+                        "Incomplete LT_I64 instruction at pc {}: missing register operands",
+                        start_pc
+                    ));
+                }
+                let r1 = bytecode[pc];
+                let r2 = bytecode[pc + 1];
+                let dst = bytecode[pc + 2];
+                pc += 3;
+                output.push_str(&format!("{} LT_I64 r{}, r{}, r{}\n", start_pc, r1, r2, dst));
+            }
+            LTE_I64 => {
+                if pc + 2 >= bytecode.len() {
+                    return Err(format!(
+                        "Incomplete LTE_I64 instruction at pc {}: missing register operands",
+                        start_pc
+                    ));
+                }
+                let r1 = bytecode[pc];
+                let r2 = bytecode[pc + 1];
+                let dst = bytecode[pc + 2];
+                pc += 3;
+                output.push_str(&format!("{} LTE_I64 r{}, r{}, r{}\n", start_pc, r1, r2, dst));
+            }
             ADD_F64 => {
                 if pc + 2 >= bytecode.len() {
                     return Err(format!(
@@ -188,6 +227,45 @@ pub fn format_bytecode(bytecode: &[u8]) -> Result<String, String> {
                 let dst = bytecode[pc + 2];
                 pc += 3;
                 output.push_str(&format!("{} GT_F64 r{}, r{}, r{}\n", start_pc, r1, r2, dst));
+            }
+            GTE_F64 => {
+                if pc + 2 >= bytecode.len() {
+                    return Err(format!(
+                        "Incomplete GTE_F64 instruction at pc {}: missing register operands",
+                        start_pc
+                    ));
+                }
+                let r1 = bytecode[pc];
+                let r2 = bytecode[pc + 1];
+                let dst = bytecode[pc + 2];
+                pc += 3;
+                output.push_str(&format!("{} GTE_F64 r{}, r{}, r{}\n", start_pc, r1, r2, dst));
+            }
+            LT_F64 => {
+                if pc + 2 >= bytecode.len() {
+                    return Err(format!(
+                        "Incomplete LT_F64 instruction at pc {}: missing register operands",
+                        start_pc
+                    ));
+                }
+                let r1 = bytecode[pc];
+                let r2 = bytecode[pc + 1];
+                let dst = bytecode[pc + 2];
+                pc += 3;
+                output.push_str(&format!("{} LT_F64 r{}, r{}, r{}\n", start_pc, r1, r2, dst));
+            }
+            LTE_F64 => {
+                if pc + 2 >= bytecode.len() {
+                    return Err(format!(
+                        "Incomplete LTE_F64 instruction at pc {}: missing register operands",
+                        start_pc
+                    ));
+                }
+                let r1 = bytecode[pc];
+                let r2 = bytecode[pc + 1];
+                let dst = bytecode[pc + 2];
+                pc += 3;
+                output.push_str(&format!("{} LTE_F64 r{}, r{}, r{}\n", start_pc, r1, r2, dst));
             }
             JUMP_FORWARD_IF_FALSE => {
                 if pc + 2 >= bytecode.len() {

--- a/src/vm/tests.rs
+++ b/src/vm/tests.rs
@@ -184,6 +184,44 @@ fn test_f64_subtraction() {
 }
 
 #[test]
+fn test_i64_comparison_ops() {
+    let mut vm = VirtualMachine::new();
+    let mut builder = BytecodeBuilder::new();
+
+    builder.load_i64(5, 1);
+    builder.load_i64(5, 2);
+    builder.gte_i64(1, 2, 0); // r0 = 1
+    builder.lt_i64(1, 2, 3); // r3 = 0
+    builder.lte_i64(1, 2, 4); // r4 = 1
+
+    let bytecode = builder.build();
+
+    vm.eval_program_with_timeout(&bytecode, Some(Duration::from_secs(1))).unwrap();
+    assert_eq!(vm.get_register_i64(0), 1);
+    assert_eq!(vm.get_register_i64(3), 0);
+    assert_eq!(vm.get_register_i64(4), 1);
+}
+
+#[test]
+fn test_f64_comparison_ops() {
+    let mut vm = VirtualMachine::new();
+    let mut builder = BytecodeBuilder::new();
+
+    builder.load_f64(2.5, 1);
+    builder.load_f64(3.0, 2);
+    builder.gte_f64(1, 2, 0); // r0 = 0
+    builder.lt_f64(1, 2, 3); // r3 = 1
+    builder.lte_f64(1, 2, 4); // r4 = 1
+
+    let bytecode = builder.build();
+
+    vm.eval_program_with_timeout(&bytecode, Some(Duration::from_secs(1))).unwrap();
+    assert_eq!(vm.get_register_i64(0), 0);
+    assert_eq!(vm.get_register_i64(3), 1);
+    assert_eq!(vm.get_register_i64(4), 1);
+}
+
+#[test]
 fn test_f64_comparison() {
     let mut vm = VirtualMachine::new();
     let mut builder = BytecodeBuilder::new();

--- a/src/vm/tests_bytecode_builder.rs
+++ b/src/vm/tests_bytecode_builder.rs
@@ -96,6 +96,25 @@ fn test_factorial_loop_with_labels() {
 }
 
 #[test]
+fn test_builder_comparison_ops() {
+    let mut vm = VirtualMachine::new();
+    let mut builder = BytecodeBuilder::new();
+
+    builder.load_i64(4, 1);
+    builder.load_i64(5, 2);
+    builder.lt_i64(1, 2, 0);
+    builder.gte_i64(1, 2, 3);
+    builder.lte_i64(1, 2, 4);
+
+    let bytecode = builder.build();
+
+    vm.eval_program_with_timeout(&bytecode, Some(Duration::from_secs(1))).unwrap();
+    assert_eq!(vm.get_register_i64(0), 1);
+    assert_eq!(vm.get_register_i64(3), 0);
+    assert_eq!(vm.get_register_i64(4), 1);
+}
+
+#[test]
 fn test_jump_forward_if_true_with_labels() {
     let mut vm = VirtualMachine::new();
     let mut builder = BytecodeBuilder::new();
@@ -297,7 +316,7 @@ fn test_fibonacci_with_labels() {
 
     builder.place_label(loop_start);
     // Check if counter >= n
-    builder.gt_i64(4, 1, 6); // r6 = (counter > n)
+    builder.gte_i64(4, 1, 6); // r6 = (counter >= n)
     builder.jump_if_true_to_label(6, loop_end);
 
     // temp = a + b

--- a/src/vm/tests_print_bytecode.rs
+++ b/src/vm/tests_print_bytecode.rs
@@ -92,6 +92,42 @@ fn test_format_gt_i64() {
 }
 
 #[test]
+fn test_format_gte_i64() {
+    let mut builder = BytecodeBuilder::new();
+    builder.gte_i64(1, 2, 3);
+    let bytecode = builder.build();
+
+    let formatted = format_bytecode(&bytecode).expect("Should format successfully");
+    let lines: Vec<&str> = formatted.lines().collect();
+
+    assert_eq!(lines[0], "0 GTE_I64 r1, r2, r3");
+}
+
+#[test]
+fn test_format_lt_i64() {
+    let mut builder = BytecodeBuilder::new();
+    builder.lt_i64(4, 5, 6);
+    let bytecode = builder.build();
+
+    let formatted = format_bytecode(&bytecode).expect("Should format successfully");
+    let lines: Vec<&str> = formatted.lines().collect();
+
+    assert_eq!(lines[0], "0 LT_I64 r4, r5, r6");
+}
+
+#[test]
+fn test_format_lte_i64() {
+    let mut builder = BytecodeBuilder::new();
+    builder.lte_i64(7, 8, 9);
+    let bytecode = builder.build();
+
+    let formatted = format_bytecode(&bytecode).expect("Should format successfully");
+    let lines: Vec<&str> = formatted.lines().collect();
+
+    assert_eq!(lines[0], "0 LTE_I64 r7, r8, r9");
+}
+
+#[test]
 fn test_format_add_f64() {
     let mut builder = BytecodeBuilder::new();
     builder.add_f64(1, 2, 3);
@@ -137,6 +173,42 @@ fn test_format_gt_f64() {
     let lines: Vec<&str> = formatted.lines().collect();
 
     assert_eq!(lines[0], "0 GT_F64 r15, r16, r17");
+}
+
+#[test]
+fn test_format_gte_f64() {
+    let mut builder = BytecodeBuilder::new();
+    builder.gte_f64(1, 2, 3);
+    let bytecode = builder.build();
+
+    let formatted = format_bytecode(&bytecode).expect("Should format successfully");
+    let lines: Vec<&str> = formatted.lines().collect();
+
+    assert_eq!(lines[0], "0 GTE_F64 r1, r2, r3");
+}
+
+#[test]
+fn test_format_lt_f64() {
+    let mut builder = BytecodeBuilder::new();
+    builder.lt_f64(4, 5, 6);
+    let bytecode = builder.build();
+
+    let formatted = format_bytecode(&bytecode).expect("Should format successfully");
+    let lines: Vec<&str> = formatted.lines().collect();
+
+    assert_eq!(lines[0], "0 LT_F64 r4, r5, r6");
+}
+
+#[test]
+fn test_format_lte_f64() {
+    let mut builder = BytecodeBuilder::new();
+    builder.lte_f64(7, 8, 9);
+    let bytecode = builder.build();
+
+    let formatted = format_bytecode(&bytecode).expect("Should format successfully");
+    let lines: Vec<&str> = formatted.lines().collect();
+
+    assert_eq!(lines[0], "0 LTE_F64 r7, r8, r9");
 }
 
 #[test]
@@ -547,6 +619,9 @@ fn test_format_incomplete_all_f64_arithmetic() {
         (SUB_F64, "SUB_F64"),
         (MUL_F64, "MUL_F64"),
         (GT_F64, "GT_F64"),
+        (GTE_F64, "GTE_F64"),
+        (LT_F64, "LT_F64"),
+        (LTE_F64, "LTE_F64"),
     ];
 
     for (opcode, name) in instructions {
@@ -561,7 +636,13 @@ fn test_format_incomplete_all_f64_arithmetic() {
 
 #[test]
 fn test_format_incomplete_all_i64_arithmetic() {
-    let instructions = vec![(MUL_I64, "MUL_I64"), (GT_I64, "GT_I64")];
+    let instructions = vec![
+        (MUL_I64, "MUL_I64"),
+        (GT_I64, "GT_I64"),
+        (GTE_I64, "GTE_I64"),
+        (LT_I64, "LT_I64"),
+        (LTE_I64, "LTE_I64"),
+    ];
 
     for (opcode, name) in instructions {
         let bytecode = vec![opcode]; // Missing all register operands


### PR DESCRIPTION
## Summary
- support new comparison instructions: GTE, LT and LTE for both i64 and f64
- extend bytecode builder and disassembler
- adjust Fibonacci example to use `gte_i64`
- add new tests for comparisons and printing

## Testing
- `RUST_TEST_THREADS=1 cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688ce357dc20832c8cd2b8ff0268996a