### PR TITLE
Add opcodes for loading constants

### DIFF
--- a/src/vm/bytecode_builder.rs
+++ b/src/vm/bytecode_builder.rs
@@ -163,6 +163,18 @@ impl BytecodeBuilder {
         self.bytecode.push(dst);
     }
 
+    pub fn load_const_value(&mut self, index: u16, reg: u8) {
+        self.bytecode.push(LOAD_CONST_VALUE);
+        self.bytecode.push(reg);
+        self.bytecode.extend_from_slice(&index.to_le_bytes());
+    }
+
+    pub fn load_const_slice(&mut self, index: u16, reg: u8) {
+        self.bytecode.push(LOAD_CONST_SLICE);
+        self.bytecode.push(reg);
+        self.bytecode.extend_from_slice(&index.to_le_bytes());
+    }
+
     pub fn i64_to_f64(&mut self, src: u8, dst: u8) {
         self.bytecode.push(I64_TO_F64);
         self.bytecode.push(src);

--- a/src/vm/print_bytecode.rs
+++ b/src/vm/print_bytecode.rs
@@ -67,6 +67,32 @@ pub fn format_bytecode(bytecode: &[u8]) -> Result<String, String> {
                 pc += 8;
                 output.push_str(&format!("{} LOAD_F64 r{}, {}\n", start_pc, reg, value));
             }
+            LOAD_CONST_VALUE => {
+                if pc + 2 >= bytecode.len() {
+                    return Err(format!(
+                        "Incomplete LOAD_CONST_VALUE instruction at pc {}: missing operands",
+                        start_pc
+                    ));
+                }
+                let reg = bytecode[pc];
+                pc += 1;
+                let index = u16::from_le_bytes([bytecode[pc], bytecode[pc + 1]]);
+                pc += 2;
+                output.push_str(&format!("{} LOAD_CONST_VALUE r{}, {}\n", start_pc, reg, index));
+            }
+            LOAD_CONST_SLICE => {
+                if pc + 2 >= bytecode.len() {
+                    return Err(format!(
+                        "Incomplete LOAD_CONST_SLICE instruction at pc {}: missing operands",
+                        start_pc
+                    ));
+                }
+                let reg = bytecode[pc];
+                pc += 1;
+                let index = u16::from_le_bytes([bytecode[pc], bytecode[pc + 1]]);
+                pc += 2;
+                output.push_str(&format!("{} LOAD_CONST_SLICE r{}, {}\n", start_pc, reg, index));
+            }
             ADD_I64 => {
                 if pc + 2 >= bytecode.len() {
                     return Err(format!(

--- a/src/vm/tests_const_opcodes.rs
+++ b/src/vm/tests_const_opcodes.rs
@@ -1,0 +1,26 @@
+use super::{BytecodeBuilder, VirtualMachine};
+use super::const_pool::{ConstPool, SliceType, ValueType};
+
+#[test]
+fn test_load_const_value_and_slice() {
+    let mut pool = ConstPool::new();
+    pool.add_value("42", 42u64, ValueType::I64);
+    pool.add_slice("hello", b"hello", SliceType::Utf8Str);
+
+    let mut vm = VirtualMachine::new();
+    vm.set_const_pool(&pool);
+
+    let mut builder = BytecodeBuilder::new();
+    let idx_v = *pool.value_name_to_index.get("42").unwrap() as u16;
+    let idx_s = *pool.slice_name_to_index.get("hello").unwrap() as u16;
+    builder.load_const_value(idx_v, 0);
+    builder.load_const_slice(idx_s, 1);
+    let bytecode = builder.build();
+
+    vm.eval_program(&bytecode).unwrap();
+    assert_eq!(vm.get_register_raw(0), pool.get_value("42").unwrap());
+    let ptr = vm.get_register_raw(1) as *const u8;
+    let len = vm.get_register_raw(2) as usize;
+    let data = unsafe { std::slice::from_raw_parts(ptr, len) };
+    assert_eq!(data, pool.get_slice("hello").unwrap());
+}

--- a/src/vm/tests_print_bytecode.rs
+++ b/src/vm/tests_print_bytecode.rs
@@ -128,6 +128,30 @@ fn test_format_lte_i64() {
 }
 
 #[test]
+fn test_format_load_const_value() {
+    let mut builder = BytecodeBuilder::new();
+    builder.load_const_value(1, 2);
+    let bytecode = builder.build();
+    let formatted = format_bytecode(&bytecode).expect("Should format successfully");
+    let lines: Vec<&str> = formatted.lines().collect();
+    assert_eq!(lines[0], "0 LOAD_CONST_VALUE r2, 1");
+    assert_eq!(lines[1], "pc=4");
+    assert_eq!(lines[2], "bytecode.len()=4");
+}
+
+#[test]
+fn test_format_load_const_slice() {
+    let mut builder = BytecodeBuilder::new();
+    builder.load_const_slice(3, 4);
+    let bytecode = builder.build();
+    let formatted = format_bytecode(&bytecode).expect("Should format successfully");
+    let lines: Vec<&str> = formatted.lines().collect();
+    assert_eq!(lines[0], "0 LOAD_CONST_SLICE r4, 3");
+    assert_eq!(lines[1], "pc=4");
+    assert_eq!(lines[2], "bytecode.len()=4");
+}
+
+#[test]
 fn test_format_add_f64() {
     let mut builder = BytecodeBuilder::new();
     builder.add_f64(1, 2, 3);


### PR DESCRIPTION
## Summary
- Add LOAD_CONST_VALUE and LOAD_CONST_SLICE opcodes and integrate constant pools into the VM
- Support building and disassembling constant-loading instructions
- Test constant pool loading, builder encoding, and bytecode formatting

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688e2fda88f8832ca8f4cedc6a85e990