### PR TITLE
Remove direct numeric load opcodes

### DIFF
--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -1,53 +1,71 @@
 use super::*;
 
 #[test]
-fn tokenize_assignment() {
-    let input = "x = 12\n";
+fn program1_tokens() {
+    let input = r#"
+x = 12
+x = x + 1
+print(x)
+"#;
     let tokens = Lexer::new(input).tokenize();
     assert_eq!(
         tokens,
         vec![
-            Token::Ident("x".to_string()),
-            Token::Equal,
-            Token::Int(12),
-            Token::Newline,
-            Token::EOF,
+            Stmt::Assign {
+                name: "x".to_string(),
+                expr: Expr::Int(12),
+            },
+            Stmt::Assign {
+                name: "x".to_string(),
+                expr: Expr::Binary {
+                    left: Box::new(Expr::Ident("x".to_string())),
+                    op: BinOp::Add,
+                    right: Box::new(Expr::Int(1)),
+                },
+            },
+            Stmt::ExprStmt(Expr::Call {
+                func: Box::new(Expr::Ident("print".to_string())),
+                args: vec![Expr::Ident("x".to_string())],
+            }),
         ]
     );
 }
 
 #[test]
-fn tokenize_print_call() {
-    let input = r#"print("hi")"#;
+fn program2_tokens() {
+    let input = r#"print("Hello, World")"#;
     let tokens = Lexer::new(input).tokenize();
     assert_eq!(
         tokens,
-        vec![
-            Token::Ident("print".to_string()),
-            Token::LParen,
-            Token::Str("hi".to_string()),
-            Token::RParen,
-            Token::EOF,
-        ]
+        vec![Stmt::ExprStmt(Expr::Call {
+            func: Box::new(Expr::Ident("print".to_string())),
+            args: vec![Expr::Str("Hello, World".to_string())],
+        }),]
     );
 }
 
 #[test]
-fn tokenize_fstring() {
-    let input = r#"print(f"{x}")"#;
+fn program3_tokens() {
+    let input = r#"
+x = 12
+print(f"{x}")
+"#;
     let tokens = Lexer::new(input).tokenize();
     assert_eq!(
         tokens,
         vec![
-            Token::Ident("print".to_string()),
-            Token::LParen,
-            Token::InterpolatedString(vec![
-                StringPart::Text("".to_string()),
-                StringPart::Expr(vec![Token::Ident("x".to_string())]),
-                StringPart::Text("".to_string()),
-            ]),
-            Token::RParen,
-            Token::EOF,
+            Stmt::Assign {
+                name: "x".to_string(),
+                expr: Expr::Int(12),
+            },
+            Stmt::ExprStmt(Expr::Call {
+                func: Box::new(Expr::Ident("print".to_string())),
+                args: vec![Expr::InterpolatedString(vec![
+                    StringPart::Text("".to_string()),
+                    StringPart::Expr(Box::new(Expr::Ident("x".to_string()))),
+                    StringPart::Text("".to_string()),
+                ])],
+            }),
         ]
     );
 }

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -1,71 +1,53 @@
 use super::*;
 
 #[test]
-fn program1_tokens() {
-    let input = r#"
-x = 12
-x = x + 1
-print(x)
-"#;
+fn tokenize_assignment() {
+    let input = "x = 12\n";
     let tokens = Lexer::new(input).tokenize();
     assert_eq!(
         tokens,
         vec![
-            Stmt::Assign {
-                name: "x".to_string(),
-                expr: Expr::Int(12),
-            },
-            Stmt::Assign {
-                name: "x".to_string(),
-                expr: Expr::Binary {
-                    left: Box::new(Expr::Ident("x".to_string())),
-                    op: BinOp::Add,
-                    right: Box::new(Expr::Int(1)),
-                },
-            },
-            Stmt::ExprStmt(Expr::Call {
-                func: Box::new(Expr::Ident("print".to_string())),
-                args: vec![Expr::Ident("x".to_string())],
-            }),
+            Token::Ident("x".to_string()),
+            Token::Equal,
+            Token::Int(12),
+            Token::Newline,
+            Token::EOF,
         ]
     );
 }
 
 #[test]
-fn program2_tokens() {
-    let input = r#"print("Hello, World")"#;
-    let tokens = Lexer::new(input).tokenize();
-    assert_eq!(
-        tokens,
-        vec![Stmt::ExprStmt(Expr::Call {
-            func: Box::new(Expr::Ident("print".to_string())),
-            args: vec![Expr::Str("Hello, World".to_string())],
-        }),]
-    );
-}
-
-#[test]
-fn program3_tokens() {
-    let input = r#"
-x = 12
-print(f"{x}")
-"#;
+fn tokenize_print_call() {
+    let input = r#"print("hi")"#;
     let tokens = Lexer::new(input).tokenize();
     assert_eq!(
         tokens,
         vec![
-            Stmt::Assign {
-                name: "x".to_string(),
-                expr: Expr::Int(12),
-            },
-            Stmt::ExprStmt(Expr::Call {
-                func: Box::new(Expr::Ident("print".to_string())),
-                args: vec![Expr::InterpolatedString(vec![
-                    StringPart::Text("".to_string()),
-                    StringPart::Expr(Box::new(Expr::Ident("x".to_string()))),
-                    StringPart::Text("".to_string()),
-                ])],
-            }),
+            Token::Ident("print".to_string()),
+            Token::LParen,
+            Token::Str("hi".to_string()),
+            Token::RParen,
+            Token::EOF,
+        ]
+    );
+}
+
+#[test]
+fn tokenize_fstring() {
+    let input = r#"print(f"{x}")"#;
+    let tokens = Lexer::new(input).tokenize();
+    assert_eq!(
+        tokens,
+        vec![
+            Token::Ident("print".to_string()),
+            Token::LParen,
+            Token::InterpolatedString(vec![
+                StringPart::Text("".to_string()),
+                StringPart::Expr(vec![Token::Ident("x".to_string())]),
+                StringPart::Text("".to_string()),
+            ]),
+            Token::RParen,
+            Token::EOF,
         ]
     );
 }

--- a/src/vm/bytecode_builder.rs
+++ b/src/vm/bytecode_builder.rs
@@ -53,18 +53,6 @@ impl BytecodeBuilder {
 
     // === BASIC INSTRUCTIONS ===
 
-    pub fn load_i64(&mut self, value: i64, reg: u8) {
-        self.bytecode.push(LOAD_I64);
-        self.bytecode.push(reg);
-        self.bytecode.extend_from_slice(&value.to_le_bytes());
-    }
-
-    pub fn load_f64(&mut self, value: f64, reg: u8) {
-        self.bytecode.push(LOAD_F64);
-        self.bytecode.push(reg);
-        self.bytecode.extend_from_slice(&value.to_le_bytes());
-    }
-
     pub fn call_host(&mut self, reg_fn_index_and_base: u16) {
         self.bytecode.push(CALL_HOST);
         self.bytecode.extend_from_slice(&reg_fn_index_and_base.to_le_bytes());

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -21,8 +21,6 @@ use std::fmt;
 use std::time::{Duration, Instant};
 
 // Instruction opcodes
-pub const LOAD_I64: u8 = 0x01;
-pub const LOAD_F64: u8 = 0x02;
 pub const ADD_I64: u8 = 0x03;
 pub const SUB_I64: u8 = 0x04;
 pub const MUL_I64: u8 = 0x05;
@@ -122,42 +120,6 @@ impl VirtualMachine {
         Ok(u16::from_le_bytes([bytecode[pos], bytecode[pos + 1]]))
     }
 
-    /// Read an i64 from bytecode at given position (little-endian)
-    fn read_i64(&self, bytecode: &[u8], pos: usize) -> Result<i64, VmError> {
-        if pos + 7 >= bytecode.len() {
-            return Err(VmError::UnexpectedEndOfProgram);
-        }
-        let bytes = [
-            bytecode[pos],
-            bytecode[pos + 1],
-            bytecode[pos + 2],
-            bytecode[pos + 3],
-            bytecode[pos + 4],
-            bytecode[pos + 5],
-            bytecode[pos + 6],
-            bytecode[pos + 7],
-        ];
-        Ok(i64::from_le_bytes(bytes))
-    }
-
-    /// Read an f64 from bytecode at given position (little-endian)
-    fn read_f64(&self, bytecode: &[u8], pos: usize) -> Result<f64, VmError> {
-        if pos + 7 >= bytecode.len() {
-            return Err(VmError::UnexpectedEndOfProgram);
-        }
-        let bytes = [
-            bytecode[pos],
-            bytecode[pos + 1],
-            bytecode[pos + 2],
-            bytecode[pos + 3],
-            bytecode[pos + 4],
-            bytecode[pos + 5],
-            bytecode[pos + 6],
-            bytecode[pos + 7],
-        ];
-        Ok(f64::from_le_bytes(bytes))
-    }
-
     /// Execute a single instruction
     fn execute_instruction(&mut self, bytecode: &[u8], pc: &mut usize) -> Result<(), VmError> {
         if *pc >= bytecode.len() {
@@ -168,28 +130,6 @@ impl VirtualMachine {
         *pc += 1;
 
         match opcode {
-            LOAD_I64 => {
-                // Format: [opcode, reg, i64_value[8]]
-                if *pc >= bytecode.len() {
-                    return Err(VmError::UnexpectedEndOfProgram);
-                }
-                let reg = bytecode[*pc] as usize;
-                *pc += 1;
-                let value = self.read_i64(bytecode, *pc)?;
-                *pc += 8;
-                self.set_i64(reg, value);
-            }
-            LOAD_F64 => {
-                // Format: [opcode, reg, f64_value[8]]
-                if *pc >= bytecode.len() {
-                    return Err(VmError::UnexpectedEndOfProgram);
-                }
-                let reg = bytecode[*pc] as usize;
-                *pc += 1;
-                let value = self.read_f64(bytecode, *pc)?;
-                *pc += 8;
-                self.set_f64(reg, value);
-            }
             ADD_I64 => {
                 // Format: [opcode, r1, r2, dst]
                 if *pc + 2 >= bytecode.len() {

--- a/src/vm/print_bytecode.rs
+++ b/src/vm/print_bytecode.rs
@@ -11,62 +11,6 @@ pub fn format_bytecode(bytecode: &[u8]) -> Result<String, String> {
         pc += 1;
 
         match opcode {
-            LOAD_I64 => {
-                if pc >= bytecode.len() {
-                    return Err(format!(
-                        "Incomplete LOAD_I64 instruction at pc {}: missing register",
-                        start_pc
-                    ));
-                }
-                let reg = bytecode[pc];
-                pc += 1;
-                if pc + 7 >= bytecode.len() {
-                    return Err(format!(
-                        "Incomplete LOAD_I64 instruction at pc {}: missing value bytes",
-                        start_pc
-                    ));
-                }
-                let value = i64::from_le_bytes([
-                    bytecode[pc],
-                    bytecode[pc + 1],
-                    bytecode[pc + 2],
-                    bytecode[pc + 3],
-                    bytecode[pc + 4],
-                    bytecode[pc + 5],
-                    bytecode[pc + 6],
-                    bytecode[pc + 7],
-                ]);
-                pc += 8;
-                output.push_str(&format!("{} LOAD_I64 r{}, {}\n", start_pc, reg, value));
-            }
-            LOAD_F64 => {
-                if pc >= bytecode.len() {
-                    return Err(format!(
-                        "Incomplete LOAD_F64 instruction at pc {}: missing register",
-                        start_pc
-                    ));
-                }
-                let reg = bytecode[pc];
-                pc += 1;
-                if pc + 7 >= bytecode.len() {
-                    return Err(format!(
-                        "Incomplete LOAD_F64 instruction at pc {}: missing value bytes",
-                        start_pc
-                    ));
-                }
-                let value = f64::from_le_bytes([
-                    bytecode[pc],
-                    bytecode[pc + 1],
-                    bytecode[pc + 2],
-                    bytecode[pc + 3],
-                    bytecode[pc + 4],
-                    bytecode[pc + 5],
-                    bytecode[pc + 6],
-                    bytecode[pc + 7],
-                ]);
-                pc += 8;
-                output.push_str(&format!("{} LOAD_F64 r{}, {}\n", start_pc, reg, value));
-            }
             LOAD_CONST_VALUE => {
                 if pc + 2 >= bytecode.len() {
                     return Err(format!(

--- a/src/vm/tests.rs
+++ b/src/vm/tests.rs
@@ -1,12 +1,23 @@
 use super::*;
+use super::const_pool::ValueType;
 use std::time::Duration;
+
+fn add_i64(vm: &mut VirtualMachine, value: i64) -> u16 {
+    vm.const_pool.add_value("", value as u64, ValueType::I64) as u16
+}
+
+fn add_f64(vm: &mut VirtualMachine, value: f64) -> u16 {
+    vm.const_pool.add_value("", value.to_bits(), ValueType::F64) as u16
+}
 
 #[test]
 fn test_basic_i64_arithmetic() {
     let mut vm = VirtualMachine::new();
+    let idx10 = add_i64(&mut vm, 10);
+    let idx5 = add_i64(&mut vm, 5);
     let mut builder = BytecodeBuilder::new();
-    builder.load_i64(10, 1);
-    builder.load_i64(5, 2);
+    builder.load_const_value(idx10, 1);
+    builder.load_const_value(idx5, 2);
     builder.add_i64(1, 2, 0);
     let bytecode = builder.build();
 
@@ -22,9 +33,11 @@ fn test_basic_i64_arithmetic() {
 #[test]
 fn test_basic_f64_arithmetic() {
     let mut vm = VirtualMachine::new();
+    let idx1 = add_f64(&mut vm, 3.14);
+    let idx2 = add_f64(&mut vm, 2.0);
     let mut builder = BytecodeBuilder::new();
-    builder.load_f64(3.14, 1);
-    builder.load_f64(2.0, 2);
+    builder.load_const_value(idx1, 1);
+    builder.load_const_value(idx2, 2);
     builder.mul_f64(1, 2, 0);
     let bytecode = builder.build();
 
@@ -41,10 +54,12 @@ fn test_basic_f64_arithmetic() {
 #[test]
 fn test_type_conversions() {
     let mut vm = VirtualMachine::new();
+    let idx42 = add_i64(&mut vm, 42);
+    let idx314 = add_f64(&mut vm, 3.14);
     let mut builder = BytecodeBuilder::new();
-    builder.load_i64(42, 1);
+    builder.load_const_value(idx42, 1);
     builder.i64_to_f64(1, 2); // r2 = 42.0
-    builder.load_f64(3.14, 3);
+    builder.load_const_value(idx314, 3);
     builder.f64_to_i64(3, 4); // r4 = 3
     builder.add_f64(2, 3, 5); // r5 = 42.0 + 3.14 = 45.14
     builder.f64_to_i64(5, 0); // r0 = 45
@@ -64,9 +79,11 @@ fn test_type_conversions() {
 #[test]
 fn test_negative_numbers() {
     let mut vm = VirtualMachine::new();
+    let idx_neg10 = add_i64(&mut vm, -10);
+    let idx5 = add_i64(&mut vm, 5);
     let mut builder = BytecodeBuilder::new();
-    builder.load_i64(-10, 1);
-    builder.load_i64(5, 2);
+    builder.load_const_value(idx_neg10, 1);
+    builder.load_const_value(idx5, 2);
     builder.add_i64(1, 2, 0); // -10 + 5 = -5
     let bytecode = builder.build();
 
@@ -82,10 +99,12 @@ fn test_negative_numbers() {
 #[test]
 fn test_mixed_arithmetic() {
     let mut vm = VirtualMachine::new();
+    let idx10 = add_i64(&mut vm, 10);
+    let idx2_5 = add_f64(&mut vm, 2.5);
     let mut builder = BytecodeBuilder::new();
-    builder.load_i64(10, 1); // r1 = 10
+    builder.load_const_value(idx10, 1); // r1 = 10
     builder.i64_to_f64(1, 2); // r2 = 10.0
-    builder.load_f64(2.5, 3); // r3 = 2.5
+    builder.load_const_value(idx2_5, 3); // r3 = 2.5
     builder.mul_f64(2, 3, 0); // r0 = 10.0 * 2.5 = 25.0
     let bytecode = builder.build();
 
@@ -115,7 +134,7 @@ fn test_invalid_opcode() {
 #[test]
 fn test_unexpected_end_of_program() {
     let mut vm = VirtualMachine::new();
-    let bytecode = vec![LOAD_I64, 1]; // Missing the i64 value
+    let bytecode = vec![LOAD_CONST_VALUE, 1]; // Missing index bytes
 
     println!("=== test_unexpected_end_of_program bytecode ===");
     print_bytecode(&bytecode);
@@ -128,8 +147,9 @@ fn test_unexpected_end_of_program() {
 #[test]
 fn test_invalid_jump_target() {
     let mut vm = VirtualMachine::new();
+    let idx1 = add_i64(&mut vm, 1);
     let mut builder = BytecodeBuilder::new();
-    builder.load_i64(1, 0);
+    builder.load_const_value(idx1, 0);
     builder.jmp_to(1000); // Invalid target - beyond program length
     let bytecode = builder.build();
 
@@ -166,10 +186,12 @@ fn test_register_raw_operations() {
 #[test]
 fn test_f64_subtraction() {
     let mut vm = VirtualMachine::new();
+    let idx1 = add_f64(&mut vm, 10.5);
+    let idx2 = add_f64(&mut vm, 3.2);
     let mut builder = BytecodeBuilder::new();
 
-    builder.load_f64(10.5, 1);
-    builder.load_f64(3.2, 2);
+    builder.load_const_value(idx1, 1);
+    builder.load_const_value(idx2, 2);
     builder.sub_f64(1, 2, 0); // r0 = 10.5 - 3.2 = 7.3
     let bytecode = builder.build();
 
@@ -186,10 +208,12 @@ fn test_f64_subtraction() {
 #[test]
 fn test_i64_comparison_ops() {
     let mut vm = VirtualMachine::new();
+    let idx5a = add_i64(&mut vm, 5);
+    let idx5b = add_i64(&mut vm, 5);
     let mut builder = BytecodeBuilder::new();
 
-    builder.load_i64(5, 1);
-    builder.load_i64(5, 2);
+    builder.load_const_value(idx5a, 1);
+    builder.load_const_value(idx5b, 2);
     builder.gte_i64(1, 2, 0); // r0 = 1
     builder.lt_i64(1, 2, 3); // r3 = 0
     builder.lte_i64(1, 2, 4); // r4 = 1
@@ -205,10 +229,12 @@ fn test_i64_comparison_ops() {
 #[test]
 fn test_f64_comparison_ops() {
     let mut vm = VirtualMachine::new();
+    let idx2_5 = add_f64(&mut vm, 2.5);
+    let idx3 = add_f64(&mut vm, 3.0);
     let mut builder = BytecodeBuilder::new();
 
-    builder.load_f64(2.5, 1);
-    builder.load_f64(3.0, 2);
+    builder.load_const_value(idx2_5, 1);
+    builder.load_const_value(idx3, 2);
     builder.gte_f64(1, 2, 0); // r0 = 0
     builder.lt_f64(1, 2, 3); // r3 = 1
     builder.lte_f64(1, 2, 4); // r4 = 1
@@ -224,16 +250,20 @@ fn test_f64_comparison_ops() {
 #[test]
 fn test_f64_comparison() {
     let mut vm = VirtualMachine::new();
+    let idx5_5 = add_f64(&mut vm, 5.5);
+    let idx3_2 = add_f64(&mut vm, 3.2);
+    let idx2_1a = add_f64(&mut vm, 2.1);
+    let idx2_1b = add_f64(&mut vm, 2.1);
     let mut builder = BytecodeBuilder::new();
 
     // Test case 1: 5.5 > 3.2 should be true (1)
-    builder.load_f64(5.5, 1);
-    builder.load_f64(3.2, 2);
+    builder.load_const_value(idx5_5, 1);
+    builder.load_const_value(idx3_2, 2);
     builder.gt_f64(1, 2, 0); // r0 = 1
 
     // Test case 2: 2.1 > 2.1 should be false (0)
-    builder.load_f64(2.1, 3);
-    builder.load_f64(2.1, 4);
+    builder.load_const_value(idx2_1a, 3);
+    builder.load_const_value(idx2_1b, 4);
     builder.gt_f64(3, 4, 5); // r5 = 0
 
     let bytecode = builder.build();
@@ -251,11 +281,13 @@ fn test_f64_comparison() {
 #[test]
 fn test_f64_comparison_with_negatives() {
     let mut vm = VirtualMachine::new();
+    let idx_neg1_5 = add_f64(&mut vm, -1.5);
+    let idx_neg2_7 = add_f64(&mut vm, -2.7);
     let mut builder = BytecodeBuilder::new();
 
     // Test: -1.5 > -2.7 should be true (1)
-    builder.load_f64(-1.5, 1);
-    builder.load_f64(-2.7, 2);
+    builder.load_const_value(idx_neg1_5, 1);
+    builder.load_const_value(idx_neg2_7, 2);
     builder.gt_f64(1, 2, 0); // r0 = 1
 
     let bytecode = builder.build();
@@ -272,13 +304,16 @@ fn test_f64_comparison_with_negatives() {
 #[test]
 fn test_complex_f64_operations() {
     let mut vm = VirtualMachine::new();
+    let idx10 = add_f64(&mut vm, 10.0);
+    let idx3 = add_f64(&mut vm, 3.0);
+    let idx5 = add_f64(&mut vm, 5.0);
     let mut builder = BytecodeBuilder::new();
 
     // Calculate (10.0 - 3.0) and check if result > 5.0
-    builder.load_f64(10.0, 1);
-    builder.load_f64(3.0, 2);
+    builder.load_const_value(idx10, 1);
+    builder.load_const_value(idx3, 2);
     builder.sub_f64(1, 2, 3); // r3 = 7.0
-    builder.load_f64(5.0, 4);
+    builder.load_const_value(idx5, 4);
     builder.gt_f64(3, 4, 0); // r0 = 1 (7.0 > 5.0)
 
     let bytecode = builder.build();
@@ -296,9 +331,10 @@ fn test_complex_f64_operations() {
 #[test]
 fn test_backward_jump_bounds_check() {
     let mut vm = VirtualMachine::new();
+    let idx1 = add_i64(&mut vm, 1);
     let mut builder = BytecodeBuilder::new();
 
-    builder.load_i64(1, 1); // r1 = 1
+    builder.load_const_value(idx1, 1); // r1 = 1
     // Try to jump backward too far (offset larger than current position)
     builder.jump_backward_if_true(1, 15); // This should cause an error when executed
 
@@ -318,11 +354,13 @@ fn test_backward_jump_bounds_check() {
 #[test]
 fn test_execution_with_timeout_no_timeout() {
     let mut vm = VirtualMachine::new();
+    let idx10 = add_i64(&mut vm, 10);
+    let idx5 = add_i64(&mut vm, 5);
     let mut builder = BytecodeBuilder::new();
 
     // Simple program that should complete quickly
-    builder.load_i64(10, 1);
-    builder.load_i64(5, 2);
+    builder.load_const_value(idx10, 1);
+    builder.load_const_value(idx5, 2);
     builder.add_i64(1, 2, 0);
     let bytecode = builder.build();
 
@@ -345,10 +383,13 @@ fn test_execution_with_short_timeout() {
     let loop_end = builder.create_label();
 
     // Create a long-running program with a tight loop
-    builder.load_i64(100000, 1); // r1 = 100000 (large counter)
-    builder.load_i64(0, 0); // r0 = 0 (accumulator)
-    builder.load_i64(1, 2); // r2 = 1 (decrement)
-    builder.load_i64(0, 3); // r3 = 0 (comparison)
+    let idx_counter = add_i64(&mut vm, 100000);
+    let idx_zero = add_i64(&mut vm, 0);
+    let idx_one = add_i64(&mut vm, 1);
+    builder.load_const_value(idx_counter, 1); // r1 = 100000 (large counter)
+    builder.load_const_value(idx_zero, 0); // r0 = 0 (accumulator)
+    builder.load_const_value(idx_one, 2); // r2 = 1 (decrement)
+    builder.load_const_value(idx_zero, 3); // r3 = 0 (comparison)
 
     // Loop start - this will run many iterations
     builder.place_label(loop_start);
@@ -381,10 +422,12 @@ fn test_execution_with_short_timeout() {
 #[test]
 fn test_execution_with_no_timeout_specified() {
     let mut vm = VirtualMachine::new();
+    let idx42 = add_i64(&mut vm, 42);
+    let idx8 = add_i64(&mut vm, 8);
     let mut builder = BytecodeBuilder::new();
 
-    builder.load_i64(42, 1);
-    builder.load_i64(8, 2);
+    builder.load_const_value(idx42, 1);
+    builder.load_const_value(idx8, 2);
     builder.mul_i64(1, 2, 0);
     let bytecode = builder.build();
 
@@ -406,8 +449,10 @@ fn test_timeout_check_interval() {
     // Create a program with exactly 999 instructions (less than TIMEOUT_CHECK_INTERVAL)
     // This tests that short programs complete without timeout checks
     for i in 0..333 {
-        builder.load_i64(i, 1);
-        builder.load_i64(1, 2);
+        let idxi = add_i64(&mut vm, i);
+        let idx1 = add_i64(&mut vm, 1);
+        builder.load_const_value(idxi, 1);
+        builder.load_const_value(idx1, 2);
         builder.add_i64(1, 2, 0); // 3 instructions per iteration = 999 total
     }
 
@@ -426,10 +471,12 @@ fn test_timeout_check_interval() {
 #[test]
 fn test_backward_compatibility() {
     let mut vm = VirtualMachine::new();
+    let idx100 = add_i64(&mut vm, 100);
+    let idx50 = add_i64(&mut vm, 50);
     let mut builder = BytecodeBuilder::new();
 
-    builder.load_i64(100, 1);
-    builder.load_i64(50, 2);
+    builder.load_const_value(idx100, 1);
+    builder.load_const_value(idx50, 2);
     builder.sub_i64(1, 2, 0);
     let bytecode = builder.build();
 

--- a/src/vm/tests_bytecode_builder.rs
+++ b/src/vm/tests_bytecode_builder.rs
@@ -2,6 +2,19 @@ use super::*;
 use super::const_pool::{ConstPool, SliceType, ValueType};
 use std::time::Duration;
 
+fn add_i64(vm: &mut VirtualMachine, value: i64) -> u16 {
+    vm.const_pool.add_value("", value as u64, ValueType::I64) as u16
+}
+
+fn add_f64(vm: &mut VirtualMachine, value: f64) -> u16 {
+    vm.const_pool.add_value("", value.to_bits(), ValueType::F64) as u16
+}
+
+fn load_i64_const(vm: &mut VirtualMachine, builder: &mut BytecodeBuilder, value: i64, reg: u8) {
+    let idx = add_i64(vm, value);
+    builder.load_const_value(idx, reg);
+}
+
 #[test]
 fn test_comparison_and_jumps_with_labels() {
     let mut vm = VirtualMachine::new();
@@ -10,16 +23,16 @@ fn test_comparison_and_jumps_with_labels() {
     let skip_label = builder.create_label();
     let end_label = builder.create_label();
 
-    builder.load_i64(10, 1); // r1 = 10
-    builder.load_i64(5, 2); // r2 = 5
+    load_i64_const(&mut vm, &mut builder, 10, 1); // r1 = 10
+    load_i64_const(&mut vm, &mut builder, 5, 2); // r2 = 5
     builder.gt_i64(1, 2, 3); // r3 = 1 (10 > 5)
 
     builder.jump_if_false_to_label(3, skip_label); // Don't jump (r3 != 0)
-    builder.load_i64(100, 0); // r0 = 100
+    load_i64_const(&mut vm, &mut builder, 100, 0); // r0 = 100
     builder.jmp_to_label(end_label);
 
     builder.place_label(skip_label);
-    builder.load_i64(200, 0); // r0 = 200 (should be skipped)
+    load_i64_const(&mut vm, &mut builder, 200, 0); // r0 = 200 (should be skipped)
 
     builder.place_label(end_label);
 
@@ -41,15 +54,15 @@ fn test_conditional_jump_with_zero() {
 
     let false_branch = builder.create_label();
 
-    builder.load_i64(5, 1); // r1 = 5
-    builder.load_i64(5, 2); // r2 = 5
+    load_i64_const(&mut vm, &mut builder, 5, 1); // r1 = 5
+    load_i64_const(&mut vm, &mut builder, 5, 2); // r2 = 5
     builder.gt_i64(1, 2, 3); // r3 = 0 (5 > 5 is false)
 
     builder.jump_if_false_to_label(3, false_branch); // Jump because r3 == 0
-    builder.load_i64(100, 0); // r0 = 100 (should be skipped)
+    load_i64_const(&mut vm, &mut builder, 100, 0); // r0 = 100 (should be skipped)
 
     builder.place_label(false_branch);
-    builder.load_i64(200, 0); // r0 = 200 (should be executed)
+    load_i64_const(&mut vm, &mut builder, 200, 0); // r0 = 200 (should be executed)
 
     let bytecode = builder.build();
 
@@ -70,10 +83,10 @@ fn test_factorial_loop_with_labels() {
     let loop_start = builder.create_label();
     let loop_end = builder.create_label();
 
-    builder.load_i64(5, 1); // r1 = 5 (counter)
-    builder.load_i64(1, 0); // r0 = 1 (result)
-    builder.load_i64(1, 2); // r2 = 1 (decrement)
-    builder.load_i64(0, 3); // r3 = 0 (comparison)
+    load_i64_const(&mut vm, &mut builder, 5, 1); // r1 = 5 (counter)
+    load_i64_const(&mut vm, &mut builder, 1, 0); // r0 = 1 (result)
+    load_i64_const(&mut vm, &mut builder, 1, 2); // r2 = 1 (decrement)
+    load_i64_const(&mut vm, &mut builder, 0, 3); // r3 = 0 (comparison)
 
     // Loop start
     builder.place_label(loop_start);
@@ -101,8 +114,8 @@ fn test_builder_comparison_ops() {
     let mut vm = VirtualMachine::new();
     let mut builder = BytecodeBuilder::new();
 
-    builder.load_i64(4, 1);
-    builder.load_i64(5, 2);
+    load_i64_const(&mut vm, &mut builder, 4, 1);
+    load_i64_const(&mut vm, &mut builder, 5, 2);
     builder.lt_i64(1, 2, 0);
     builder.gte_i64(1, 2, 3);
     builder.lte_i64(1, 2, 4);
@@ -123,13 +136,13 @@ fn test_jump_forward_if_true_with_labels() {
     let target_label = builder.create_label();
 
     // Set up a true condition
-    builder.load_i64(1, 1); // r1 = 1 (true)
+    load_i64_const(&mut vm, &mut builder, 1, 1); // r1 = 1 (true)
 
     builder.jump_if_true_to_label(1, target_label); // Jump because r1 != 0
-    builder.load_i64(100, 0); // r0 = 100 (should be skipped)
+    load_i64_const(&mut vm, &mut builder, 100, 0); // r0 = 100 (should be skipped)
 
     builder.place_label(target_label);
-    builder.load_i64(200, 0); // r0 = 200 (should be executed)
+    load_i64_const(&mut vm, &mut builder, 200, 0); // r0 = 200 (should be executed)
 
     let bytecode = builder.build();
 
@@ -150,13 +163,13 @@ fn test_jump_forward_if_true_false_condition() {
     let target_label = builder.create_label();
 
     // Set up a false condition
-    builder.load_i64(0, 1); // r1 = 0 (false)
+    load_i64_const(&mut vm, &mut builder, 0, 1); // r1 = 0 (false)
 
     builder.jump_if_true_to_label(1, target_label); // Don't jump since r1 == 0
-    builder.load_i64(100, 0); // r0 = 100 (should be executed)
+    load_i64_const(&mut vm, &mut builder, 100, 0); // r0 = 100 (should be executed)
 
     builder.place_label(target_label);
-    builder.load_i64(200, 0); // r0 = 200 (should also be executed)
+    load_i64_const(&mut vm, &mut builder, 200, 0); // r0 = 200 (should also be executed)
 
     let bytecode = builder.build();
 
@@ -176,9 +189,9 @@ fn test_jump_backward_if_true_loop() {
 
     let loop_start = builder.create_label();
 
-    builder.load_i64(3, 1); // r1 = 3 (counter)
-    builder.load_i64(0, 0); // r0 = 0 (accumulator)
-    builder.load_i64(1, 2); // r2 = 1 (decrement value)
+    load_i64_const(&mut vm, &mut builder, 3, 1); // r1 = 3 (counter)
+    load_i64_const(&mut vm, &mut builder, 0, 0); // r0 = 0 (accumulator)
+    load_i64_const(&mut vm, &mut builder, 1, 2); // r2 = 1 (decrement value)
 
     // Loop start
     builder.place_label(loop_start);
@@ -205,10 +218,10 @@ fn test_jump_backward_if_false_exit_loop() {
 
     let loop_start = builder.create_label();
 
-    builder.load_i64(0, 1); // r1 = 0 (counter)
-    builder.load_i64(0, 0); // r0 = 0 (accumulator)
-    builder.load_i64(1, 2); // r2 = 1 (increment value)
-    builder.load_i64(5, 3); // r3 = 5 (target value)
+    load_i64_const(&mut vm, &mut builder, 0, 1); // r1 = 0 (counter)
+    load_i64_const(&mut vm, &mut builder, 0, 0); // r0 = 0 (accumulator)
+    load_i64_const(&mut vm, &mut builder, 1, 2); // r2 = 1 (increment value)
+    load_i64_const(&mut vm, &mut builder, 5, 3); // r3 = 5 (target value)
 
     // Loop start
     builder.place_label(loop_start);
@@ -238,24 +251,24 @@ fn test_nested_conditional_jumps_with_labels() {
     let inner_else = builder.create_label();
     let end_label = builder.create_label();
 
-    builder.load_i64(1, 1); // r1 = 1 (first condition - true)
-    builder.load_i64(0, 2); // r2 = 0 (second condition - false)
+    load_i64_const(&mut vm, &mut builder, 1, 1); // r1 = 1 (first condition - true)
+    load_i64_const(&mut vm, &mut builder, 0, 2); // r2 = 0 (second condition - false)
 
     builder.jump_if_false_to_label(1, else_branch); // Don't jump since r1 != 0
 
     // Inner conditional
     builder.jump_if_false_to_label(2, inner_else); // Jump since r2 == 0
-    builder.load_i64(300, 0); // r0 = 300 (should be skipped)
+    load_i64_const(&mut vm, &mut builder, 300, 0); // r0 = 300 (should be skipped)
     builder.jmp_to_label(end_label);
 
     // Inner else
     builder.place_label(inner_else);
-    builder.load_i64(200, 0); // r0 = 200 (should be executed)
+    load_i64_const(&mut vm, &mut builder, 200, 0); // r0 = 200 (should be executed)
     builder.jmp_to_label(end_label);
 
     // Outer else
     builder.place_label(else_branch);
-    builder.load_i64(100, 0); // r0 = 100 (should be skipped)
+    load_i64_const(&mut vm, &mut builder, 100, 0); // r0 = 100 (should be skipped)
 
     builder.place_label(end_label);
 
@@ -275,19 +288,19 @@ fn test_target_based_jumps() {
     let mut vm = VirtualMachine::new();
     let mut builder = BytecodeBuilder::new();
 
-    builder.load_i64(10, 1); // r1 = 10
-    builder.load_i64(5, 2); // r2 = 5
+    load_i64_const(&mut vm, &mut builder, 10, 1); // r1 = 10
+    load_i64_const(&mut vm, &mut builder, 5, 2); // r2 = 5
     builder.gt_i64(1, 2, 3); // r3 = 1 (10 > 5)
 
     // Calculate target position for the jump
     let current_pos = builder.current_pos();
-    let skip_instruction_size = 10; // LOAD_I64 instruction size
+    let skip_instruction_size = 4; // LOAD_CONST_VALUE instruction size
     let target = current_pos + 3 + skip_instruction_size; // +3 for jump instruction size
 
     builder.jump_forward_if_false_to(3, target); // Won't jump since r3 != 0
-    builder.load_i64(100, 0); // r0 = 100 (should be executed)
+    load_i64_const(&mut vm, &mut builder, 100, 0); // r0 = 100 (should be executed)
     // target is here
-    builder.load_i64(200, 0); // r0 = 200 (should also be executed)
+    load_i64_const(&mut vm, &mut builder, 200, 0); // r0 = 200 (should also be executed)
 
     let bytecode = builder.build();
 
@@ -309,11 +322,11 @@ fn test_fibonacci_with_labels() {
     let loop_end = builder.create_label();
 
     // Calculate 10th Fibonacci number
-    builder.load_i64(10, 1); // r1 = n (target)
-    builder.load_i64(0, 2); // r2 = a (previous)
-    builder.load_i64(1, 3); // r3 = b (current)
-    builder.load_i64(1, 4); // r4 = counter
-    builder.load_i64(1, 5); // r5 = increment
+    load_i64_const(&mut vm, &mut builder, 10, 1); // r1 = n (target)
+    load_i64_const(&mut vm, &mut builder, 0, 2); // r2 = a (previous)
+    load_i64_const(&mut vm, &mut builder, 1, 3); // r3 = b (current)
+    load_i64_const(&mut vm, &mut builder, 1, 4); // r4 = counter
+    load_i64_const(&mut vm, &mut builder, 1, 5); // r5 = increment
 
     builder.place_label(loop_start);
     // Check if counter >= n
@@ -355,14 +368,14 @@ fn test_comparison_old_vs_new_approach() {
 
     // OLD APPROACH: Manual patching
     let mut old_builder = BytecodeBuilder::new();
-    old_builder.load_i64(10, 1);
-    old_builder.load_i64(5, 2);
+    load_i64_const(&mut vm1, &mut old_builder, 10, 1);
+    load_i64_const(&mut vm1, &mut old_builder, 5, 2);
     old_builder.gt_i64(1, 2, 3);
 
     let target_pos = old_builder.jump_forward_if_false(3);
-    old_builder.load_i64(100, 0);
+    load_i64_const(&mut vm1, &mut old_builder, 100, 0);
     let end_pos = old_builder.current_pos();
-    old_builder.load_i64(200, 0);
+    load_i64_const(&mut vm1, &mut old_builder, 200, 0);
 
     old_builder.patch_target(target_pos, end_pos - target_pos);
     let old_bytecode = old_builder.build();
@@ -371,13 +384,13 @@ fn test_comparison_old_vs_new_approach() {
     let mut new_builder = BytecodeBuilder::new();
     let skip_label = new_builder.create_label();
 
-    new_builder.load_i64(10, 1);
-    new_builder.load_i64(5, 2);
+    load_i64_const(&mut vm2, &mut new_builder, 10, 1);
+    load_i64_const(&mut vm2, &mut new_builder, 5, 2);
     new_builder.gt_i64(1, 2, 3);
     new_builder.jump_if_false_to_label(3, skip_label);
-    new_builder.load_i64(100, 0);
+    load_i64_const(&mut vm2, &mut new_builder, 100, 0);
     new_builder.place_label(skip_label);
-    new_builder.load_i64(200, 0);
+    load_i64_const(&mut vm2, &mut new_builder, 200, 0);
 
     let new_bytecode = new_builder.build();
 
@@ -409,8 +422,8 @@ fn test_complex_control_flow() {
     let end_label = builder.create_label();
 
     // Classify a number as positive, negative, or zero
-    builder.load_i64(-5, 1); // r1 = -5 (test value)
-    builder.load_i64(0, 2); // r2 = 0 (comparison)
+    load_i64_const(&mut vm, &mut builder, -5, 1); // r1 = -5 (test value)
+    load_i64_const(&mut vm, &mut builder, 0, 2); // r2 = 0 (comparison)
 
     // Check if equal to zero
     builder.sub_i64(1, 2, 3); // r3 = value - 0
@@ -423,15 +436,15 @@ fn test_complex_control_flow() {
     builder.jmp_to_label(negative_branch);
 
     builder.place_label(positive_branch);
-    builder.load_i64(1, 0); // r0 = 1 (positive)
+    load_i64_const(&mut vm, &mut builder, 1, 0); // r0 = 1 (positive)
     builder.jmp_to_label(end_label);
 
     builder.place_label(negative_branch);
-    builder.load_i64(-1, 0); // r0 = -1 (negative)
+    load_i64_const(&mut vm, &mut builder, -1, 0); // r0 = -1 (negative)
     builder.jmp_to_label(end_label);
 
     builder.place_label(zero_branch);
-    builder.load_i64(0, 0); // r0 = 0 (zero)
+    load_i64_const(&mut vm, &mut builder, 0, 0); // r0 = 0 (zero)
 
     builder.place_label(end_label);
 
@@ -469,8 +482,9 @@ fn test_builder_load_const_instructions() {
 fn test_error_handling_with_labels() {
     // Test that unresolved labels cause panics
     let result = std::panic::catch_unwind(|| {
+        let mut vm = VirtualMachine::new();
         let mut builder = BytecodeBuilder::new();
-        builder.load_i64(1, 1);
+        load_i64_const(&mut vm, &mut builder, 1, 1);
         builder.jump_if_true_to_label(1, 999); // Non-existent label
         let _bytecode = builder.build(); // Should panic here
     });
@@ -483,8 +497,9 @@ fn test_error_handling_with_labels() {
 fn test_target_based_error_handling() {
     // Test forward jump with invalid target
     let result = std::panic::catch_unwind(|| {
+        let mut vm = VirtualMachine::new();
         let mut builder = BytecodeBuilder::new();
-        builder.load_i64(1, 1);
+        load_i64_const(&mut vm, &mut builder, 1, 1);
         let current = builder.current_pos();
         builder.jump_forward_if_false_to(1, current - 1); // Invalid: backwards target
     });
@@ -492,8 +507,9 @@ fn test_target_based_error_handling() {
 
     // Test backward jump with invalid target
     let result = std::panic::catch_unwind(|| {
+        let mut vm = VirtualMachine::new();
         let mut builder = BytecodeBuilder::new();
-        builder.load_i64(1, 1);
+        load_i64_const(&mut vm, &mut builder, 1, 1);
         let current = builder.current_pos();
         builder.jump_backward_if_false_to(1, current + 10); // Invalid: forwards target
     });

--- a/src/vm/tests_call.rs
+++ b/src/vm/tests_call.rs
@@ -1,4 +1,14 @@
 use super::*;
+use super::const_pool::ValueType;
+
+fn add_i64(vm: &mut VirtualMachine, value: i64) -> u16 {
+    vm.const_pool.add_value("", value as u64, ValueType::I64) as u16
+}
+
+fn add_fn(vm: &mut VirtualMachine, index: usize) -> u16 {
+    vm.const_pool
+        .add_value("", index as u64, ValueType::FuncHost) as u16
+}
 
 fn inc(base: usize, registers: &mut Registers) -> Result<(), String> {
     let val = registers.get(base + 1);
@@ -13,9 +23,11 @@ fn test_call_host_basic() {
         .host_functions
         .register("inc", 1, 1, 2, inc);
 
+    let fn_idx_const = add_fn(&mut vm, fn_index);
+    let idx41 = add_i64(&mut vm, 41);
     let mut builder = BytecodeBuilder::new();
-    builder.load_i64(fn_index as i64, 10);
-    builder.load_i64(41, 11);
+    builder.load_const_value(fn_idx_const, 10);
+    builder.load_const_value(idx41, 11);
     builder.call_host(10);
     let bytecode = builder.build();
 
@@ -26,8 +38,9 @@ fn test_call_host_basic() {
 #[test]
 fn test_call_host_invalid_index() {
     let mut vm = VirtualMachine::new();
+    let idx = add_i64(&mut vm, 999);
     let mut builder = BytecodeBuilder::new();
-    builder.load_i64(999, 0);
+    builder.load_const_value(idx, 0);
     builder.call_host(0);
     let bytecode = builder.build();
 
@@ -42,10 +55,13 @@ fn test_call_host_register_isolation() {
         .host_functions
         .register("inc", 1, 1, 2, inc);
 
+    let idx77 = add_i64(&mut vm, 77);
+    let fn_idx_const = add_fn(&mut vm, fn_index);
+    let idx1 = add_i64(&mut vm, 1);
     let mut builder = BytecodeBuilder::new();
-    builder.load_i64(77, 5);
-    builder.load_i64(fn_index as i64, 10);
-    builder.load_i64(1, 11);
+    builder.load_const_value(idx77, 5);
+    builder.load_const_value(fn_idx_const, 10);
+    builder.load_const_value(idx1, 11);
     builder.call_host(10);
     let bytecode = builder.build();
 
@@ -60,13 +76,15 @@ fn test_call_host_multiple_calls() {
     let fn_index = vm
         .host_functions
         .register("inc", 1, 1, 2, inc);
-
+    let fn_idx_const = add_fn(&mut vm, fn_index);
+    let idx5 = add_i64(&mut vm, 5);
+    let idx100 = add_i64(&mut vm, 100);
     let mut builder = BytecodeBuilder::new();
-    builder.load_i64(fn_index as i64, 10);
-    builder.load_i64(5, 11);
+    builder.load_const_value(fn_idx_const, 10);
+    builder.load_const_value(idx5, 11);
     builder.call_host(10);
-    builder.load_i64(fn_index as i64, 20);
-    builder.load_i64(100, 21);
+    builder.load_const_value(fn_idx_const, 20);
+    builder.load_const_value(idx100, 21);
     builder.call_host(20);
     let bytecode = builder.build();
 


### PR DESCRIPTION
## Summary
- Drop `LOAD_I64` and `LOAD_F64` opcodes in favor of loading all constants from the pool
- Update bytecode printing and call tests to use constant pool indices, including host function indices
- Rewrite lexer tests for current tokenization and adapt print-bytecode tests to new constant loading

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688f5c67960c832cad48aa24a2101085