### PR TITLE
Implement AST lexer and parser

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -1,8 +1,46 @@
 use std::iter::Peekable;
 use std::str::Chars;
 
+// ===== Abstract syntax tree =====
+
 #[derive(Debug, Clone, PartialEq)]
-pub enum Token {
+pub enum Stmt {
+    Assign { name: String, expr: Expr },
+    ExprStmt(Expr),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expr {
+    Int(i64),
+    Str(String),
+    Ident(String),
+    Binary {
+        left: Box<Expr>,
+        op: BinOp,
+        right: Box<Expr>,
+    },
+    Call {
+        func: Box<Expr>,
+        args: Vec<Expr>,
+    },
+    InterpolatedString(Vec<StringPart>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum BinOp {
+    Add,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum StringPart {
+    Text(String),
+    Expr(Box<Expr>),
+}
+
+// ===== Tokens for the lexer =====
+
+#[derive(Debug, Clone, PartialEq)]
+enum Token {
     Int(i64),
     Str(String),
     Ident(String),
@@ -16,22 +54,27 @@ pub enum Token {
     InterpolatedString(Vec<StringPart>),
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum StringPart {
-    Text(String),
-    Expr(Vec<Token>),
-}
-
 pub struct Lexer<'a> {
     chars: Peekable<Chars<'a>>,
 }
 
 impl<'a> Lexer<'a> {
     pub fn new(input: &'a str) -> Self {
-        Self { chars: input.chars().peekable() }
+        Self {
+            chars: input.chars().peekable(),
+        }
     }
 
-    pub fn tokenize(mut self) -> Vec<Token> {
+    /// Tokenize the input into a list of statements.
+    pub fn tokenize(mut self) -> Vec<Stmt> {
+        let tokens = self.collect_tokens();
+        let mut parser = Parser::new(tokens);
+        parser.parse_program()
+    }
+
+    /// Collect raw tokens from the input. The resulting token stream will
+    /// always be terminated with `Token::EOF`.
+    fn collect_tokens(&mut self) -> Vec<Token> {
         let mut tokens = Vec::new();
         loop {
             let tok = self.next_token();
@@ -144,20 +187,17 @@ impl<'a> Lexer<'a> {
             match c {
                 '"' => break,
                 '{' => {
-                    // parse expression
-                    let mut expr = String::new();
+                    // collect expression between braces and parse it
+                    let mut expr_src = String::new();
                     while let Some(ch) = self.chars.next() {
                         if ch == '}' {
                             break;
                         } else {
-                            expr.push(ch);
+                            expr_src.push(ch);
                         }
                     }
-                    let mut inner = Lexer::new(&expr).tokenize();
-                    if matches!(inner.last(), Some(Token::EOF)) {
-                        inner.pop();
-                    }
-                    parts.push(StringPart::Expr(inner));
+                    let expr = parse_embedded_expr(&expr_src);
+                    parts.push(StringPart::Expr(Box::new(expr)));
                     parts.push(StringPart::Text(String::new()));
                     current_index = parts.len() - 1;
                 }
@@ -186,6 +226,147 @@ impl<'a> Lexer<'a> {
         iter.next();
         iter.peek().copied()
     }
+}
+
+// ===== Parser implementation =====
+
+struct Parser {
+    tokens: Vec<Token>,
+    pos: usize,
+}
+
+impl Parser {
+    fn new(tokens: Vec<Token>) -> Self {
+        Self { tokens, pos: 0 }
+    }
+
+    fn parse_program(&mut self) -> Vec<Stmt> {
+        let mut stmts = Vec::new();
+        self.skip_newlines();
+        while !self.is_at_end() {
+            if let Some(stmt) = self.parse_stmt() {
+                stmts.push(stmt);
+            }
+            self.skip_newlines();
+        }
+        stmts
+    }
+
+    fn parse_stmt(&mut self) -> Option<Stmt> {
+        if self.is_at_end() {
+            return None;
+        }
+        if let Token::Ident(name) = self.peek().clone() {
+            if self.peek_next_is(Token::Equal) {
+                self.advance(); // ident
+                self.advance(); // '='
+                let expr = self.parse_expr();
+                return Some(Stmt::Assign { name, expr });
+            }
+        }
+        let expr = self.parse_expr();
+        Some(Stmt::ExprStmt(expr))
+    }
+
+    fn parse_expr(&mut self) -> Expr {
+        let mut left = self.parse_primary();
+        while matches!(self.peek(), Token::Plus) {
+            self.advance();
+            let right = self.parse_primary();
+            left = Expr::Binary {
+                left: Box::new(left),
+                op: BinOp::Add,
+                right: Box::new(right),
+            };
+        }
+        left
+    }
+
+    fn parse_primary(&mut self) -> Expr {
+        match self.advance() {
+            Token::Int(n) => Expr::Int(n),
+            Token::Str(s) => Expr::Str(s),
+            Token::Ident(s) => {
+                let expr = Expr::Ident(s);
+                self.parse_call(expr)
+            }
+            Token::InterpolatedString(parts) => Expr::InterpolatedString(parts),
+            Token::LParen => {
+                let expr = self.parse_expr();
+                self.expect(Token::RParen);
+                self.parse_call(expr)
+            }
+            other => panic!("Unexpected token {:?}", other),
+        }
+    }
+
+    fn parse_call(&mut self, mut expr: Expr) -> Expr {
+        loop {
+            match self.peek() {
+                Token::LParen => {
+                    self.advance(); // consume '(' 
+                    let mut args = Vec::new();
+                    if !matches!(self.peek(), Token::RParen) {
+                        args.push(self.parse_expr());
+                        while matches!(self.peek(), Token::Comma) {
+                            self.advance();
+                            args.push(self.parse_expr());
+                        }
+                    }
+                    self.expect(Token::RParen);
+                    expr = Expr::Call {
+                        func: Box::new(expr),
+                        args,
+                    };
+                }
+                _ => break,
+            }
+        }
+        expr
+    }
+
+    fn skip_newlines(&mut self) {
+        while matches!(self.peek(), Token::Newline) {
+            self.advance();
+        }
+    }
+
+    fn expect(&mut self, expected: Token) {
+        let tok = self.advance();
+        if tok != expected {
+            panic!("expected {:?}, found {:?}", expected, tok);
+        }
+    }
+
+    fn peek(&self) -> Token {
+        self.tokens.get(self.pos).cloned().unwrap_or(Token::EOF)
+    }
+
+    fn peek_next_is(&self, expected: Token) -> bool {
+        self.tokens
+            .get(self.pos + 1)
+            .cloned()
+            .map_or(false, |t| t == expected)
+    }
+
+    fn advance(&mut self) -> Token {
+        let tok = self.peek();
+        if !self.is_at_end() {
+            self.pos += 1;
+        }
+        tok
+    }
+
+    fn is_at_end(&self) -> bool {
+        matches!(self.peek(), Token::EOF)
+    }
+}
+
+fn parse_embedded_expr(src: &str) -> Expr {
+    let mut lexer = Lexer::new(src);
+    let tokens = lexer.collect_tokens();
+    let mut parser = Parser::new(tokens);
+    parser.parse_expr()
 }
 
 mod tests;


### PR DESCRIPTION
## Summary
- Replace token-only lexer with full AST generation, introducing `Stmt`, `Expr`, and `BinOp`
- Add parser that converts raw tokens into statements and expressions
- Support interpolated strings with embedded expression parsing

## Testing
- `cargo test -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_688f5c8e0a4c832c860b65d3cfa7c851