### PR TITLE
Split lexer and parser modules with dedicated tests

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -1,46 +1,8 @@
 use std::iter::Peekable;
 use std::str::Chars;
 
-// ===== Abstract syntax tree =====
-
 #[derive(Debug, Clone, PartialEq)]
-pub enum Stmt {
-    Assign { name: String, expr: Expr },
-    ExprStmt(Expr),
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum Expr {
-    Int(i64),
-    Str(String),
-    Ident(String),
-    Binary {
-        left: Box<Expr>,
-        op: BinOp,
-        right: Box<Expr>,
-    },
-    Call {
-        func: Box<Expr>,
-        args: Vec<Expr>,
-    },
-    InterpolatedString(Vec<StringPart>),
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum BinOp {
-    Add,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum StringPart {
-    Text(String),
-    Expr(Box<Expr>),
-}
-
-// ===== Tokens for the lexer =====
-
-#[derive(Debug, Clone, PartialEq)]
-enum Token {
+pub enum Token {
     Int(i64),
     Str(String),
     Ident(String),
@@ -51,7 +13,13 @@ enum Token {
     Comma,
     Newline,
     EOF,
-    InterpolatedString(Vec<StringPart>),
+    InterpolatedString(Vec<FStringPart>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum FStringPart {
+    Text(String),
+    Expr(String),
 }
 
 pub struct Lexer<'a> {
@@ -60,21 +28,11 @@ pub struct Lexer<'a> {
 
 impl<'a> Lexer<'a> {
     pub fn new(input: &'a str) -> Self {
-        Self {
-            chars: input.chars().peekable(),
-        }
+        Self { chars: input.chars().peekable() }
     }
 
-    /// Tokenize the input into a list of statements.
-    pub fn tokenize(mut self) -> Vec<Stmt> {
-        let tokens = self.collect_tokens();
-        let mut parser = Parser::new(tokens);
-        parser.parse_program()
-    }
-
-    /// Collect raw tokens from the input. The resulting token stream will
-    /// always be terminated with `Token::EOF`.
-    fn collect_tokens(&mut self) -> Vec<Token> {
+    /// Tokenize the input. The resulting token stream will always end with `Token::EOF`.
+    pub fn tokenize(mut self) -> Vec<Token> {
         let mut tokens = Vec::new();
         loop {
             let tok = self.next_token();
@@ -181,13 +139,12 @@ impl<'a> Lexer<'a> {
     fn lex_fstring(&mut self) -> Token {
         self.chars.next(); // consume 'f'
         self.chars.next(); // consume opening quote
-        let mut parts = vec![StringPart::Text(String::new())];
+        let mut parts = vec![FStringPart::Text(String::new())];
         let mut current_index = 0; // index of current text part
         while let Some(c) = self.chars.next() {
             match c {
                 '"' => break,
                 '{' => {
-                    // collect expression between braces and parse it
                     let mut expr_src = String::new();
                     while let Some(ch) = self.chars.next() {
                         if ch == '}' {
@@ -196,13 +153,12 @@ impl<'a> Lexer<'a> {
                             expr_src.push(ch);
                         }
                     }
-                    let expr = parse_embedded_expr(&expr_src);
-                    parts.push(StringPart::Expr(Box::new(expr)));
-                    parts.push(StringPart::Text(String::new()));
+                    parts.push(FStringPart::Expr(expr_src));
+                    parts.push(FStringPart::Text(String::new()));
                     current_index = parts.len() - 1;
                 }
                 _ => {
-                    if let StringPart::Text(ref mut t) = parts[current_index] {
+                    if let FStringPart::Text(ref mut t) = parts[current_index] {
                         t.push(c);
                     }
                 }
@@ -226,147 +182,6 @@ impl<'a> Lexer<'a> {
         iter.next();
         iter.peek().copied()
     }
-}
-
-// ===== Parser implementation =====
-
-struct Parser {
-    tokens: Vec<Token>,
-    pos: usize,
-}
-
-impl Parser {
-    fn new(tokens: Vec<Token>) -> Self {
-        Self { tokens, pos: 0 }
-    }
-
-    fn parse_program(&mut self) -> Vec<Stmt> {
-        let mut stmts = Vec::new();
-        self.skip_newlines();
-        while !self.is_at_end() {
-            if let Some(stmt) = self.parse_stmt() {
-                stmts.push(stmt);
-            }
-            self.skip_newlines();
-        }
-        stmts
-    }
-
-    fn parse_stmt(&mut self) -> Option<Stmt> {
-        if self.is_at_end() {
-            return None;
-        }
-        if let Token::Ident(name) = self.peek().clone() {
-            if self.peek_next_is(Token::Equal) {
-                self.advance(); // ident
-                self.advance(); // '='
-                let expr = self.parse_expr();
-                return Some(Stmt::Assign { name, expr });
-            }
-        }
-        let expr = self.parse_expr();
-        Some(Stmt::ExprStmt(expr))
-    }
-
-    fn parse_expr(&mut self) -> Expr {
-        let mut left = self.parse_primary();
-        while matches!(self.peek(), Token::Plus) {
-            self.advance();
-            let right = self.parse_primary();
-            left = Expr::Binary {
-                left: Box::new(left),
-                op: BinOp::Add,
-                right: Box::new(right),
-            };
-        }
-        left
-    }
-
-    fn parse_primary(&mut self) -> Expr {
-        match self.advance() {
-            Token::Int(n) => Expr::Int(n),
-            Token::Str(s) => Expr::Str(s),
-            Token::Ident(s) => {
-                let expr = Expr::Ident(s);
-                self.parse_call(expr)
-            }
-            Token::InterpolatedString(parts) => Expr::InterpolatedString(parts),
-            Token::LParen => {
-                let expr = self.parse_expr();
-                self.expect(Token::RParen);
-                self.parse_call(expr)
-            }
-            other => panic!("Unexpected token {:?}", other),
-        }
-    }
-
-    fn parse_call(&mut self, mut expr: Expr) -> Expr {
-        loop {
-            match self.peek() {
-                Token::LParen => {
-                    self.advance(); // consume '(' 
-                    let mut args = Vec::new();
-                    if !matches!(self.peek(), Token::RParen) {
-                        args.push(self.parse_expr());
-                        while matches!(self.peek(), Token::Comma) {
-                            self.advance();
-                            args.push(self.parse_expr());
-                        }
-                    }
-                    self.expect(Token::RParen);
-                    expr = Expr::Call {
-                        func: Box::new(expr),
-                        args,
-                    };
-                }
-                _ => break,
-            }
-        }
-        expr
-    }
-
-    fn skip_newlines(&mut self) {
-        while matches!(self.peek(), Token::Newline) {
-            self.advance();
-        }
-    }
-
-    fn expect(&mut self, expected: Token) {
-        let tok = self.advance();
-        if tok != expected {
-            panic!("expected {:?}, found {:?}", expected, tok);
-        }
-    }
-
-    fn peek(&self) -> Token {
-        self.tokens.get(self.pos).cloned().unwrap_or(Token::EOF)
-    }
-
-    fn peek_next_is(&self, expected: Token) -> bool {
-        self.tokens
-            .get(self.pos + 1)
-            .cloned()
-            .map_or(false, |t| t == expected)
-    }
-
-    fn advance(&mut self) -> Token {
-        let tok = self.peek();
-        if !self.is_at_end() {
-            self.pos += 1;
-        }
-        tok
-    }
-
-    fn is_at_end(&self) -> bool {
-        matches!(self.peek(), Token::EOF)
-    }
-}
-
-fn parse_embedded_expr(src: &str) -> Expr {
-    let mut lexer = Lexer::new(src);
-    let tokens = lexer.collect_tokens();
-    let mut parser = Parser::new(tokens);
-    parser.parse_expr()
 }
 
 mod tests;

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -2,8 +2,7 @@ use super::*;
 
 #[test]
 fn program1_tokens() {
-    let input = r#"
-x = 12
+    let input = r#"x = 12
 x = x + 1
 print(x)
 "#;
@@ -11,22 +10,22 @@ print(x)
     assert_eq!(
         tokens,
         vec![
-            Stmt::Assign {
-                name: "x".to_string(),
-                expr: Expr::Int(12),
-            },
-            Stmt::Assign {
-                name: "x".to_string(),
-                expr: Expr::Binary {
-                    left: Box::new(Expr::Ident("x".to_string())),
-                    op: BinOp::Add,
-                    right: Box::new(Expr::Int(1)),
-                },
-            },
-            Stmt::ExprStmt(Expr::Call {
-                func: Box::new(Expr::Ident("print".to_string())),
-                args: vec![Expr::Ident("x".to_string())],
-            }),
+            Token::Ident("x".to_string()),
+            Token::Equal,
+            Token::Int(12),
+            Token::Newline,
+            Token::Ident("x".to_string()),
+            Token::Equal,
+            Token::Ident("x".to_string()),
+            Token::Plus,
+            Token::Int(1),
+            Token::Newline,
+            Token::Ident("print".to_string()),
+            Token::LParen,
+            Token::Ident("x".to_string()),
+            Token::RParen,
+            Token::Newline,
+            Token::EOF,
         ]
     );
 }
@@ -37,35 +36,39 @@ fn program2_tokens() {
     let tokens = Lexer::new(input).tokenize();
     assert_eq!(
         tokens,
-        vec![Stmt::ExprStmt(Expr::Call {
-            func: Box::new(Expr::Ident("print".to_string())),
-            args: vec![Expr::Str("Hello, World".to_string())],
-        }),]
+        vec![
+            Token::Ident("print".to_string()),
+            Token::LParen,
+            Token::Str("Hello, World".to_string()),
+            Token::RParen,
+            Token::EOF,
+        ]
     );
 }
 
 #[test]
 fn program3_tokens() {
-    let input = r#"
-x = 12
+    let input = r#"x = 12
 print(f"{x}")
 "#;
     let tokens = Lexer::new(input).tokenize();
     assert_eq!(
         tokens,
         vec![
-            Stmt::Assign {
-                name: "x".to_string(),
-                expr: Expr::Int(12),
-            },
-            Stmt::ExprStmt(Expr::Call {
-                func: Box::new(Expr::Ident("print".to_string())),
-                args: vec![Expr::InterpolatedString(vec![
-                    StringPart::Text("".to_string()),
-                    StringPart::Expr(Box::new(Expr::Ident("x".to_string()))),
-                    StringPart::Text("".to_string()),
-                ])],
-            }),
+            Token::Ident("x".to_string()),
+            Token::Equal,
+            Token::Int(12),
+            Token::Newline,
+            Token::Ident("print".to_string()),
+            Token::LParen,
+            Token::InterpolatedString(vec![
+                FStringPart::Text("".to_string()),
+                FStringPart::Expr("x".to_string()),
+                FStringPart::Text("".to_string()),
+            ]),
+            Token::RParen,
+            Token::Newline,
+            Token::EOF,
         ]
     );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod vm;
 mod write;
 mod lexer;
+mod parser;
 fn main() {
     write::println_to_console(b"Hello, World!");
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,187 @@
+use crate::lexer::{Lexer, Token, FStringPart};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Stmt {
+    Assign { name: String, expr: Expr },
+    ExprStmt(Expr),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expr {
+    Int(i64),
+    Str(String),
+    Ident(String),
+    Binary {
+        left: Box<Expr>,
+        op: BinOp,
+        right: Box<Expr>,
+    },
+    Call {
+        func: Box<Expr>,
+        args: Vec<Expr>,
+    },
+    InterpolatedString(Vec<StringPart>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum BinOp {
+    Add,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum StringPart {
+    Text(String),
+    Expr(Box<Expr>),
+}
+
+pub struct Parser {
+    tokens: Vec<Token>,
+    pos: usize,
+}
+
+impl Parser {
+    pub fn new(tokens: Vec<Token>) -> Self {
+        Self { tokens, pos: 0 }
+    }
+
+    pub fn parse_program(&mut self) -> Vec<Stmt> {
+        let mut stmts = Vec::new();
+        self.skip_newlines();
+        while !self.is_at_end() {
+            if let Some(stmt) = self.parse_stmt() {
+                stmts.push(stmt);
+            }
+            self.skip_newlines();
+        }
+        stmts
+    }
+
+    pub fn parse_expr(&mut self) -> Expr {
+        let mut left = self.parse_primary();
+        while matches!(self.peek(), Token::Plus) {
+            self.advance();
+            let right = self.parse_primary();
+            left = Expr::Binary {
+                left: Box::new(left),
+                op: BinOp::Add,
+                right: Box::new(right),
+            };
+        }
+        left
+    }
+
+    fn parse_stmt(&mut self) -> Option<Stmt> {
+        if self.is_at_end() {
+            return None;
+        }
+        if let Token::Ident(name) = self.peek().clone() {
+            if self.peek_next_is(Token::Equal) {
+                self.advance(); // ident
+                self.advance(); // '='
+                let expr = self.parse_expr();
+                return Some(Stmt::Assign { name, expr });
+            }
+        }
+        let expr = self.parse_expr();
+        Some(Stmt::ExprStmt(expr))
+    }
+
+    fn parse_primary(&mut self) -> Expr {
+        match self.advance() {
+            Token::Int(n) => Expr::Int(n),
+            Token::Str(s) => Expr::Str(s),
+            Token::Ident(s) => {
+                let expr = Expr::Ident(s);
+                self.parse_call(expr)
+            }
+            Token::InterpolatedString(parts) => {
+                let mut ast_parts = Vec::new();
+                for part in parts {
+                    match part {
+                        FStringPart::Text(t) => ast_parts.push(StringPart::Text(t)),
+                        FStringPart::Expr(src) => {
+                            let expr = parse_embedded_expr(&src);
+                            ast_parts.push(StringPart::Expr(Box::new(expr)));
+                        }
+                    }
+                }
+                Expr::InterpolatedString(ast_parts)
+            }
+            Token::LParen => {
+                let expr = self.parse_expr();
+                self.expect(Token::RParen);
+                self.parse_call(expr)
+            }
+            other => panic!("Unexpected token {:?}", other),
+        }
+    }
+
+    fn parse_call(&mut self, mut expr: Expr) -> Expr {
+        loop {
+            match self.peek() {
+                Token::LParen => {
+                    self.advance(); // consume '('
+                    let mut args = Vec::new();
+                    if !matches!(self.peek(), Token::RParen) {
+                        args.push(self.parse_expr());
+                        while matches!(self.peek(), Token::Comma) {
+                            self.advance();
+                            args.push(self.parse_expr());
+                        }
+                    }
+                    self.expect(Token::RParen);
+                    expr = Expr::Call {
+                        func: Box::new(expr),
+                        args,
+                    };
+                }
+                _ => break,
+            }
+        }
+        expr
+    }
+
+    fn skip_newlines(&mut self) {
+        while matches!(self.peek(), Token::Newline) {
+            self.advance();
+        }
+    }
+
+    fn expect(&mut self, expected: Token) {
+        let tok = self.advance();
+        if tok != expected {
+            panic!("expected {:?}, found {:?}", expected, tok);
+        }
+    }
+
+    fn peek(&self) -> Token {
+        self.tokens.get(self.pos).cloned().unwrap_or(Token::EOF)
+    }
+
+    fn peek_next_is(&self, expected: Token) -> bool {
+        self.tokens
+            .get(self.pos + 1)
+            .cloned()
+            .map_or(false, |t| t == expected)
+    }
+
+    fn advance(&mut self) -> Token {
+        let tok = self.peek();
+        if !self.is_at_end() {
+            self.pos += 1;
+        }
+        tok
+    }
+
+    fn is_at_end(&self) -> bool {
+        matches!(self.peek(), Token::EOF)
+    }
+}
+
+fn parse_embedded_expr(src: &str) -> Expr {
+    let tokens = Lexer::new(src).tokenize();
+    let mut parser = Parser::new(tokens);
+    parser.parse_expr()
+}
+
+mod tests;

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1,0 +1,73 @@
+use super::*;
+use crate::lexer::Lexer;
+
+#[test]
+fn program1_ast() {
+    let input = r#"x = 12
+x = x + 1
+print(x)
+"#;
+    let tokens = Lexer::new(input).tokenize();
+    let ast = Parser::new(tokens).parse_program();
+    assert_eq!(
+        ast,
+        vec![
+            Stmt::Assign {
+                name: "x".to_string(),
+                expr: Expr::Int(12),
+            },
+            Stmt::Assign {
+                name: "x".to_string(),
+                expr: Expr::Binary {
+                    left: Box::new(Expr::Ident("x".to_string())),
+                    op: BinOp::Add,
+                    right: Box::new(Expr::Int(1)),
+                },
+            },
+            Stmt::ExprStmt(Expr::Call {
+                func: Box::new(Expr::Ident("print".to_string())),
+                args: vec![Expr::Ident("x".to_string())],
+            }),
+        ]
+    );
+}
+
+#[test]
+fn program2_ast() {
+    let input = r#"print("Hello, World")"#;
+    let tokens = Lexer::new(input).tokenize();
+    let ast = Parser::new(tokens).parse_program();
+    assert_eq!(
+        ast,
+        vec![Stmt::ExprStmt(Expr::Call {
+            func: Box::new(Expr::Ident("print".to_string())),
+            args: vec![Expr::Str("Hello, World".to_string())],
+        })]
+    );
+}
+
+#[test]
+fn program3_ast() {
+    let input = r#"x = 12
+print(f"{x}")
+"#;
+    let tokens = Lexer::new(input).tokenize();
+    let ast = Parser::new(tokens).parse_program();
+    assert_eq!(
+        ast,
+        vec![
+            Stmt::Assign {
+                name: "x".to_string(),
+                expr: Expr::Int(12),
+            },
+            Stmt::ExprStmt(Expr::Call {
+                func: Box::new(Expr::Ident("print".to_string())),
+                args: vec![Expr::InterpolatedString(vec![
+                    StringPart::Text("".to_string()),
+                    StringPart::Expr(Box::new(Expr::Ident("x".to_string()))),
+                    StringPart::Text("".to_string()),
+                ])],
+            }),
+        ]
+    );
+}


### PR DESCRIPTION
## Summary
- Refactor lexer to emit token streams, including f-string tokens, without AST construction
- Introduce new parser module to build ASTs from tokens and handle string interpolation expressions
- Add unit tests for lexer and parser covering three sample programs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_688f6cdd9ff0832c809429a0655d43d3