### PR TITLE
Add bytecode generator with sample program tests

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1,0 +1,145 @@
+use crate::parser::{Expr, Stmt, BinOp};
+use crate::vm::{BytecodeBuilder, VirtualMachine};
+use crate::vm::const_pool::{SliceType, ValueType};
+use std::collections::HashMap;
+
+#[derive(Clone, Copy, PartialEq)]
+enum ValueKind {
+    Int,
+    Str,
+}
+
+struct CodeGenerator<'a> {
+    builder: BytecodeBuilder,
+    vars: HashMap<String, u8>,
+    types: HashMap<String, ValueKind>,
+    next_reg: u8,
+    vm: &'a mut VirtualMachine,
+    print_const: u16,
+}
+
+impl<'a> CodeGenerator<'a> {
+    fn new(vm: &'a mut VirtualMachine, print_const: u16) -> Self {
+        Self {
+            builder: BytecodeBuilder::new(),
+            vars: HashMap::new(),
+            types: HashMap::new(),
+            next_reg: 1, // reserve register 0 for call base
+            vm,
+            print_const,
+        }
+    }
+
+    fn compile(mut self, stmts: &[Stmt]) -> Vec<u8> {
+        for stmt in stmts {
+            self.gen_stmt(stmt);
+        }
+        self.builder.build()
+    }
+
+    fn gen_stmt(&mut self, stmt: &Stmt) {
+        match stmt {
+            Stmt::Assign { name, expr } => {
+                let reg = *self.vars.entry(name.clone()).or_insert_with(|| {
+                    let r = self.next_reg;
+                    self.next_reg += 1;
+                    r
+                });
+                let (_r, kind) = self.gen_expr(expr, Some(reg));
+                self.types.insert(name.clone(), kind);
+            }
+            Stmt::ExprStmt(expr) => {
+                if let Expr::Call { func, args } = expr {
+                    if let Expr::Ident(fname) = &**func {
+                        if fname == "print" && args.len() == 1 {
+                            self.gen_print(&args[0]);
+                            return;
+                        }
+                    }
+                    panic!("unsupported call expression");
+                } else {
+                    self.gen_expr(expr, None);
+                }
+            }
+        }
+    }
+
+    fn gen_print(&mut self, arg: &Expr) {
+        let (reg, kind) = self.gen_expr(arg, None);
+        let base = reg - 1;
+        if self.next_reg <= base + 2 {
+            self.next_reg = base + 3;
+        }
+        self.builder.load_const_value(self.print_const, base);
+        if kind == ValueKind::Int {
+            let zero_idx = self.vm.const_pool.add_value("", 0, ValueType::I64) as u16;
+            self.builder.load_const_value(zero_idx, base + 2);
+        }
+        self.builder.call_host(base as u16);
+    }
+
+    fn gen_expr(&mut self, expr: &Expr, target: Option<u8>) -> (u8, ValueKind) {
+        match expr {
+            Expr::Int(n) => {
+                let reg = target.unwrap_or_else(|| {
+                    let r = self.next_reg;
+                    self.next_reg += 1;
+                    r
+                });
+                let idx = self
+                    .vm
+                    .const_pool
+                    .add_value("", *n as u64, ValueType::I64) as u16;
+                self.builder.load_const_value(idx, reg);
+                (reg, ValueKind::Int)
+            }
+            Expr::Str(s) => {
+                let reg = target.unwrap_or_else(|| {
+                    let r = self.next_reg;
+                    self.next_reg += 2;
+                    r
+                });
+                if target.is_some() && self.next_reg <= reg + 1 {
+                    self.next_reg = reg + 2;
+                }
+                let idx = self
+                    .vm
+                    .const_pool
+                    .add_slice("", s.as_bytes(), SliceType::Utf8Str) as u16;
+                self.builder.load_const_slice(idx, reg);
+                (reg, ValueKind::Str)
+            }
+            Expr::Ident(name) => {
+                let reg = *self
+                    .vars
+                    .get(name)
+                    .expect("undefined variable");
+                let kind = *self
+                    .types
+                    .get(name)
+                    .expect("unknown type");
+                (reg, kind)
+            }
+            Expr::Binary { left, op: BinOp::Add, right } => {
+                let (lreg, _) = self.gen_expr(left, target);
+                let (rreg, _) = self.gen_expr(right, None);
+                let dst = target.unwrap_or(lreg);
+                self.builder.add_i64(lreg, rreg, dst);
+                (dst, ValueKind::Int)
+            }
+            Expr::Call { .. } => panic!("call expressions not supported here"),
+            Expr::InterpolatedString(_) => unimplemented!("f-strings not supported"),
+        }
+    }
+}
+
+pub fn generate_bytecode(
+    stmts: &[Stmt],
+    vm: &mut VirtualMachine,
+    print_const: u16,
+) -> Vec<u8> {
+    CodeGenerator::new(vm, print_const).compile(stmts)
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -1,0 +1,76 @@
+use super::*;
+use crate::lexer::Lexer;
+use crate::parser::Parser;
+use crate::vm::{Registers, VirtualMachine};
+use crate::vm::const_pool::ValueType;
+use std::sync::{Mutex, OnceLock};
+
+static OUTPUT: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+fn output() -> &'static Mutex<Vec<String>> {
+    OUTPUT.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+static TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+fn host_print(base: usize, registers: &mut Registers) -> Result<(), String> {
+    let val = registers.get(base + 1);
+    let len = registers.get(base + 2);
+    if len == 0 {
+        output().lock().unwrap().push(format!("{}", val as i64));
+    } else {
+        unsafe {
+            let slice = std::slice::from_raw_parts(val as *const u8, len as usize);
+            let s = String::from_utf8(slice.to_vec()).map_err(|e| e.to_string())?;
+            output().lock().unwrap().push(s);
+        }
+    }
+    Ok(())
+}
+
+fn setup_vm() -> (VirtualMachine, u16) {
+    let mut vm = VirtualMachine::new();
+    let print_idx = vm
+        .host_functions
+        .register("print", 0, 1, 3, host_print);
+    let const_idx = vm
+        .const_pool
+        .add_value("", print_idx as u64, ValueType::FuncHost) as u16;
+    (vm, const_idx)
+}
+
+#[test]
+fn program1_codegen() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let src = r#"x = 12
+x = x + 1
+print(x)
+"#;
+    let tokens = Lexer::new(src).tokenize();
+    let mut parser = Parser::new(tokens);
+    let stmts = parser.parse_program();
+
+    let (mut vm, print_const) = setup_vm();
+    output().lock().unwrap().clear();
+    let bytecode = generate_bytecode(&stmts, &mut vm, print_const);
+    vm.eval_program(&bytecode).unwrap();
+
+    let out = output().lock().unwrap().clone();
+    assert_eq!(out, vec!["13".to_string()]);
+}
+
+#[test]
+fn program2_codegen() {
+    let _guard = TEST_MUTEX.lock().unwrap();
+    let src = r#"print("Hello, World")"#;
+    let tokens = Lexer::new(src).tokenize();
+    let mut parser = Parser::new(tokens);
+    let stmts = parser.parse_program();
+
+    let (mut vm, print_const) = setup_vm();
+    output().lock().unwrap().clear();
+    let bytecode = generate_bytecode(&stmts, &mut vm, print_const);
+    vm.eval_program(&bytecode).unwrap();
+
+    let out = output().lock().unwrap().clone();
+    assert_eq!(out, vec!["Hello, World".to_string()]);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod vm;
 mod write;
 mod lexer;
 mod parser;
+mod codegen;
 fn main() {
     write::println_to_console(b"Hello, World!");
 }

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -1,5 +1,5 @@
 mod bytecode_builder;
-mod const_pool;
+pub mod const_pool;
 mod print_bytecode;
 mod registers;
 mod call;


### PR DESCRIPTION
## Summary
- implement a simple bytecode generator translating parser AST into VM bytecode and handling assignments, addition, and print calls
- test code generation using the lexer’s first two example programs
- expose VM constant pool and wire codegen module into main

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688f7360e2d0832ca34fd584a6dc55b1