### PR TITLE
Track call base in VM state

### DIFF
--- a/src/vm/call.rs
+++ b/src/vm/call.rs
@@ -1,5 +1,4 @@
 use super::registers::Registers;
-use super::VirtualMachine;
 
 pub type HostFn = fn(base: usize, registers: &mut Registers) -> Result<(), String>;
 
@@ -48,15 +47,3 @@ pub enum CallInfo {
     CallHost { base: usize, top: usize, host_fn_index: usize },
 }
 
-impl VirtualMachine {
-    pub fn current_base(&self) -> usize {
-        self.call_stack
-            .last()
-            .map(|info| match info {
-                CallInfo::Global { base, .. } => *base,
-                CallInfo::Call { base, .. } => *base,
-                CallInfo::CallHost { base, .. } => *base,
-            })
-            .unwrap_or(0)
-    }
-}


### PR DESCRIPTION
## Summary
- add `base` field to `VirtualMachine`
- update `CALL_HOST` execution to maintain `vm.base`
- remove `current_base` helper

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689265bee078832c9ef61aa0b5df35d7