### PR TITLE
Add global variable registry

### DIFF
--- a/src/vm/global_vars.rs
+++ b/src/vm/global_vars.rs
@@ -1,0 +1,55 @@
+use std::collections::HashMap;
+
+use super::const_pool::{SliceType, ValueType};
+
+#[derive(Debug, Clone, Copy)]
+pub enum PtrType {
+    Slice(SliceType),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum GlobalVarType {
+    Value(ValueType),
+    Ptr(PtrType),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct GlobalVarMeta {
+    pub typ: GlobalVarType,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct GlobalVar {
+    pub register_id: usize,
+    pub meta: GlobalVarMeta,
+}
+
+#[derive(Debug, Default)]
+pub struct GlobalVars {
+    vars: HashMap<String, GlobalVar>,
+}
+
+impl GlobalVars {
+    pub fn new() -> Self {
+        Self { vars: HashMap::new() }
+    }
+
+    pub fn insert(&mut self, name: &str, register_id: usize, typ: GlobalVarType) {
+        self.vars.insert(
+            name.to_string(),
+            GlobalVar {
+                register_id,
+                meta: GlobalVarMeta { typ },
+            },
+        );
+    }
+
+    pub fn get(&self, name: &str) -> Option<&GlobalVar> {
+        self.vars.get(name)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.vars.is_empty()
+    }
+}
+

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -1,5 +1,6 @@
 mod bytecode_builder;
 pub mod const_pool;
+mod global_vars;
 mod print_bytecode;
 mod registers;
 mod call;
@@ -10,11 +11,13 @@ mod tests_const_pool;
 mod tests_print_bytecode;
 mod tests_registers;
 mod tests_call;
+mod tests_global_vars;
 
 pub use bytecode_builder::BytecodeBuilder;
 pub use print_bytecode::print_bytecode;
 pub use registers::Registers;
 pub use call::{HostFunctionRegistry, CallInfo};
+pub use global_vars::GlobalVars;
 
 use const_pool::ConstPool;
 use std::fmt;
@@ -81,6 +84,7 @@ pub struct VirtualMachine {
     pub host_functions: HostFunctionRegistry,
     pub call_stack: Vec<CallInfo>,
     pub base: usize,
+    pub global_vars: GlobalVars,
 }
 
 impl VirtualMachine {
@@ -91,6 +95,7 @@ impl VirtualMachine {
             host_functions: HostFunctionRegistry::new(),
             call_stack: vec![CallInfo::Global { base: 0, top: 0 }],
             base: 0,
+            global_vars: GlobalVars::new(),
         }
     }
 

--- a/src/vm/tests_global_vars.rs
+++ b/src/vm/tests_global_vars.rs
@@ -1,0 +1,35 @@
+use super::const_pool::{SliceType, ValueType};
+use super::global_vars::{GlobalVars, GlobalVarType, PtrType};
+use super::VirtualMachine;
+
+#[test]
+fn test_insert_and_get_value_var() {
+    let mut gv = GlobalVars::new();
+    gv.insert("counter", 1, GlobalVarType::Value(ValueType::I64));
+    let var = gv.get("counter").expect("var exists");
+    assert_eq!(var.register_id, 1);
+    assert!(matches!(var.meta.typ, GlobalVarType::Value(ValueType::I64)));
+}
+
+#[test]
+fn test_insert_and_get_ptr_var() {
+    let mut gv = GlobalVars::new();
+    gv.insert(
+        "greeting",
+        2,
+        GlobalVarType::Ptr(PtrType::Slice(SliceType::Utf8Str)),
+    );
+    let var = gv.get("greeting").unwrap();
+    assert_eq!(var.register_id, 2);
+    assert!(matches!(
+        var.meta.typ,
+        GlobalVarType::Ptr(PtrType::Slice(SliceType::Utf8Str))
+    ));
+}
+
+#[test]
+fn test_vm_has_global_vars() {
+    let vm = VirtualMachine::new();
+    assert!(vm.global_vars.is_empty());
+}
+


### PR DESCRIPTION
## Summary
- introduce `GlobalVars` registry with metadata for value and slice pointer types
- integrate global variable registry into `VirtualMachine`
- test global variable insertion, retrieval, and VM initialization

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68927cbf444c832cbe90e7cfa2dae576