### PR TITLE
Populate global vars during codegen

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1,5 +1,5 @@
 use crate::parser::{Expr, Stmt, BinOp};
-use crate::vm::{BytecodeBuilder, VirtualMachine};
+use crate::vm::{BytecodeBuilder, VirtualMachine, GlobalVarType, PtrType};
 use crate::vm::const_pool::{SliceType, ValueType};
 use std::collections::HashMap;
 
@@ -47,6 +47,14 @@ impl<'a> CodeGenerator<'a> {
                 });
                 let (_r, kind) = self.gen_expr(expr, Some(reg));
                 self.types.insert(name.clone(), kind);
+
+                let gv_type = match kind {
+                    ValueKind::Int => GlobalVarType::Value(ValueType::I64),
+                    ValueKind::Str => GlobalVarType::Ptr(PtrType::Slice(SliceType::Utf8Str)),
+                };
+                self.vm
+                    .global_vars
+                    .insert(name, reg as usize, gv_type);
             }
             Stmt::ExprStmt(expr) => {
                 if let Expr::Call { func, args } = expr {

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -17,7 +17,7 @@ pub use bytecode_builder::BytecodeBuilder;
 pub use print_bytecode::print_bytecode;
 pub use registers::Registers;
 pub use call::{HostFunctionRegistry, CallInfo};
-pub use global_vars::GlobalVars;
+pub use global_vars::{GlobalVars, GlobalVarType, PtrType};
 
 use const_pool::ConstPool;
 use std::fmt;


### PR DESCRIPTION
## Summary
- track assigned variables in `global_vars` when generating bytecode
- re-export global variable metadata types from VM module
- add unit test ensuring code generation populates `global_vars`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68930c3c4f54832c9534e80ccb603568