### PR TITLE
Add register type tracking

### DIFF
--- a/src/vm/const_pool.rs
+++ b/src/vm/const_pool.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 // Value constants
 //
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ValueType {
     I64,
     F64,
@@ -25,7 +25,7 @@ pub struct ValueConstMeta {
 // Slice constants
 //
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SliceType {
     Utf8Str,
     Binary,

--- a/src/vm/global_vars.rs
+++ b/src/vm/global_vars.rs
@@ -2,23 +2,23 @@ use std::collections::HashMap;
 
 use super::const_pool::{SliceType, ValueType};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PtrType {
     Slice(SliceType),
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GlobalVarType {
     Value(ValueType),
     Ptr(PtrType),
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GlobalVarMeta {
     pub typ: GlobalVarType,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GlobalVar {
     pub register_id: usize,
     pub meta: GlobalVarMeta,

--- a/src/vm/register_types.rs
+++ b/src/vm/register_types.rs
@@ -1,0 +1,78 @@
+use super::global_vars::GlobalVarType;
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegisterType {
+    /// Default value register
+    ValueRegister = 0,
+    /// Main register for an allocated pointer variable, carrying its type
+    AllocatedPtrVarMain(GlobalVarType),
+    /// Additional register for an allocated pointer variable (e.g. length)
+    AllocatedPtrVarOther = 2,
+    /// Register holding pointer to constant slice data
+    ConstSliceVarMain = 5,
+    /// Register holding length for constant slice
+    ConstSliceVarLen = 6,
+}
+
+impl Default for RegisterType {
+    fn default() -> Self {
+        RegisterType::ValueRegister
+    }
+}
+
+pub struct RegisterTypes {
+    fixed: [RegisterType; super::registers::Registers::FIXED_COUNT],
+    spill: Vec<RegisterType>,
+}
+
+impl RegisterTypes {
+    pub const FIXED_COUNT: usize = super::registers::Registers::FIXED_COUNT;
+    pub const SPILL_INIT: usize = super::registers::Registers::SPILL_INIT;
+
+    pub fn new() -> Self {
+        Self {
+            fixed: [RegisterType::ValueRegister; Self::FIXED_COUNT],
+            spill: Vec::with_capacity(Self::SPILL_INIT),
+        }
+    }
+
+    pub fn get(&self, index: usize) -> RegisterType {
+        if index < Self::FIXED_COUNT {
+            self.fixed[index]
+        } else {
+            let spill_index = index - Self::FIXED_COUNT;
+            self.spill.get(spill_index).copied().unwrap_or_default()
+        }
+    }
+
+    pub fn set(&mut self, index: usize, value: RegisterType) {
+        if index < Self::FIXED_COUNT {
+            self.fixed[index] = value;
+        } else {
+            let spill_index = index - Self::FIXED_COUNT;
+            if spill_index >= self.spill.len() {
+                self.spill
+                    .resize(spill_index + 1, RegisterType::ValueRegister);
+            }
+            self.spill[spill_index] = value;
+        }
+    }
+
+    pub fn ensure_len(&mut self, len: usize) {
+        if len <= Self::FIXED_COUNT {
+            return;
+        }
+        let spill_needed = len - Self::FIXED_COUNT;
+        if spill_needed > self.spill.len() {
+            self.spill
+                .resize(spill_needed, RegisterType::ValueRegister);
+        }
+    }
+}
+
+impl Default for RegisterTypes {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/vm/tests_const_opcodes.rs
+++ b/src/vm/tests_const_opcodes.rs
@@ -1,5 +1,5 @@
 use super::const_pool::{SliceType, ValueType};
-use super::{BytecodeBuilder, VirtualMachine};
+use super::{BytecodeBuilder, VirtualMachine, RegisterType};
 
 #[test]
 fn test_load_const_value_and_slice() {
@@ -24,4 +24,12 @@ fn test_load_const_value_and_slice() {
     let len = vm.get_register_raw(2) as usize;
     let data = unsafe { std::slice::from_raw_parts(ptr, len) };
     assert_eq!(data, vm.const_pool.get_slice("hello").unwrap());
+    assert_eq!(
+        vm.get_register_type(1),
+        RegisterType::ConstSliceVarMain
+    );
+    assert_eq!(
+        vm.get_register_type(2),
+        RegisterType::ConstSliceVarLen
+    );
 }


### PR DESCRIPTION
## Summary
- Track register types with new `RegisterType` enum and storage
- Store register type info in `VirtualMachine` and tag UTF-8 slice constants
- Test constant slice opcodes for correct register typing

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689318d21554832c8404671a53a8a508